### PR TITLE
Add support for scripting schemas.

### DIFF
--- a/model/Table.cs
+++ b/model/Table.cs
@@ -6,6 +6,18 @@ using System.Linq;
 using System.Text;
 
 namespace model {
+	public class Schema
+	{
+		public string Name;
+		public string Owner;
+
+		public Schema(string name, string owner)
+		{
+			Owner = owner;
+			Name = name;
+		}
+	}
+
 	public class Table {
 		public ColumnList Columns = new ColumnList();
 		public List<Constraint> Constraints = new List<Constraint>();

--- a/test/DatabaseTester.cs
+++ b/test/DatabaseTester.cs
@@ -172,8 +172,8 @@ namespace test {
 			TestHelper.DropDb("TEST_TEMP");
 
 			foreach (Table t in db.Tables) {
-				Assert.IsNotNull(db2.FindTable(t.Name));
-				Assert.IsFalse(db2.FindTable(t.Name).Compare(t).IsDiff);
+				Assert.IsNotNull(db2.FindTable(t.Name, t.Owner));
+				Assert.IsFalse(db2.FindTable(t.Name, t.Owner).Compare(t).IsDiff);
 			}
 		}
 
@@ -181,8 +181,8 @@ namespace test {
 		public void TestScriptDeletedProc() {
 			var source = new Database();
 			source.Routines.Add(new Routine("dbo", "test"));
-			source.FindRoutine("test").Type = "PROCEDURE";
-			source.FindRoutine("test").Text = @"
+			source.FindRoutine("test", "dbo").Type = "PROCEDURE";
+			source.FindRoutine("test", "dbo").Text = @"
 create procedure [dbo].[test]
 as 
 select * from Table1


### PR DESCRIPTION
Added Schema class to the model.
During "Script" operation, writes new "schemas.sql" script that creates DB schemas.
When scripting objects to SQL files, all files are named as "[{schema}].[{object_name}].sql" to avoid conflicts.
This resolves the previously reported [issue](https://github.com/sethreno/schemazen/issues/20) with having the same table name in two different schemas (e.g. app.batch and import.batch).
