### PR TITLE
Handle sql column type 'image'

### DIFF
--- a/model/Column.cs
+++ b/model/Column.cs
@@ -146,6 +146,7 @@ namespace SchemaZen.model {
 				case "uniqueidentifier":
 					return typeof(Guid);
 				case "varbinary":
+				case "image":
 					return typeof(byte[]);
 				default:
 					return typeof(string);

--- a/model/Table.cs
+++ b/model/Table.cs
@@ -197,6 +197,7 @@ namespace SchemaZen.model {
 				case "uniqueidentifier":
 					return new Guid(val);
 				case "varbinary":
+				case "image":
 					return SoapHexBinary.Parse(val).Value;
 				default:
 					return val;


### PR DESCRIPTION
Avoid throwing errors caused by trying to convert string to sql-type 'image' (which is actually varbinary).