### PR TITLE
Largefiles

### DIFF
--- a/model/Database.cs
+++ b/model/Database.cs
@@ -1201,7 +1201,7 @@ end
 					continue;
 				}
 				try {
-					t.ImportData(Connection, File.ReadAllText(fi.FullName));
+					t.ImportData(Connection, fi.FullName);
 				} catch (DataException ex) {
 					throw new DataFileException(ex.Message, fi.FullName, ex.LineNumber);
 				} catch (SqlBatchException ex) {

--- a/model/Table.cs
+++ b/model/Table.cs
@@ -190,7 +190,7 @@ namespace SchemaZen.model {
 						batch_rows = 0;
 						bulk = new SqlBulkCopy(conn,
 								SqlBulkCopyOptions.KeepIdentity | SqlBulkCopyOptions.TableLock);
-						bulk.DestinationTableName = Name;
+						bulk.DestinationTableName = string.Format("[{0}]", Name);
 						bulk.WriteToServer(dt);
 						bulk.Close();
 						dt.Clear();
@@ -200,7 +200,7 @@ namespace SchemaZen.model {
 
 			bulk = new SqlBulkCopy(conn,
 					SqlBulkCopyOptions.KeepIdentity | SqlBulkCopyOptions.TableLock);
-			bulk.DestinationTableName = Name;
+			bulk.DestinationTableName = string.Format("[{0}]", Name);
 			bulk.WriteToServer(dt);
 			bulk.Close();
 		}

--- a/model/Table.cs
+++ b/model/Table.cs
@@ -210,7 +210,7 @@ namespace SchemaZen.model {
 						batch_rows = 0;
 						bulk = new SqlBulkCopy(conn,
 								SqlBulkCopyOptions.KeepIdentity | SqlBulkCopyOptions.TableLock);
-						bulk.DestinationTableName = string.Format("[{0}]", Name);
+						bulk.DestinationTableName = string.Format("[{0}].[{1}]", Owner, Name);
 						bulk.WriteToServer(dt);
 						bulk.Close();
 						dt.Clear();
@@ -220,7 +220,7 @@ namespace SchemaZen.model {
 
 			bulk = new SqlBulkCopy(conn,
 					SqlBulkCopyOptions.KeepIdentity | SqlBulkCopyOptions.TableLock);
-			bulk.DestinationTableName = string.Format("[{0}]", Name);
+			bulk.DestinationTableName = string.Format("[{0}].[{1}]", Owner, Name);
 			bulk.WriteToServer(dt);
 			bulk.Close();
 		}

--- a/test/TableTester.cs
+++ b/test/TableTester.cs
@@ -87,11 +87,19 @@ namespace SchemaZen.test {
 2	P	Processing
 3	F	Frozen
 ";
+			string filename =  Path.GetTempFileName();
 
-			t.ImportData(conn, dataIn);
+			StreamWriter writer = File.AppendText(filename);
+			writer.Write(dataIn);
+			writer.Flush();
+			writer.Close();
+
+			t.ImportData(conn, filename);
 			var sw = new StringWriter();
 			t.ExportData(conn, sw);
 			Assert.AreEqual(dataIn, sw.ToString());
+
+			File.Delete(filename);
 		}
 
 		[Test]


### PR DESCRIPTION
Allow data to be imported for large tables, by reading row-by-row from the source file, and bulkinserting 'rowsInBatch' rows at a time (set to 15000).