### PR TITLE
Fix for #38, #44 and #45

### DIFF
--- a/console/Script.cs
+++ b/console/Script.cs
@@ -50,6 +50,16 @@ namespace SchemaZen.console
 			db.ScriptToDir(TableHint);
 
 			Console.WriteLine("Snapshot successfully created at " + db.Dir);
+			var routinesWithWarnings = db.Routines.Select(r => new {
+																	   Routine = r,
+																	   Warnings = r.Warnings().ToList()
+																   }).Where(r => r.Warnings.Any()).ToList();
+			if (routinesWithWarnings.Any()) {
+				Console.WriteLine("With the following warnings:");
+				foreach (var warning in routinesWithWarnings.SelectMany(r => r.Warnings.Select(w => "- " + r.Routine.RoutineType.ToString() + " " + r.Routine.Name + ": " + w))) {
+					Console.WriteLine(warning);
+				}
+			}
 			return 0;
 		}
 

--- a/console/Script.cs
+++ b/console/Script.cs
@@ -56,7 +56,7 @@ namespace SchemaZen.console
 																   }).Where(r => r.Warnings.Any()).ToList();
 			if (routinesWithWarnings.Any()) {
 				Console.WriteLine("With the following warnings:");
-				foreach (var warning in routinesWithWarnings.SelectMany(r => r.Warnings.Select(w => "- " + r.Routine.RoutineType.ToString() + " " + r.Routine.Name + ": " + w))) {
+				foreach (var warning in routinesWithWarnings.SelectMany(r => r.Warnings.Select(w => string.Format("- {0} [{1}].[{2}]: {3}", r.Routine.RoutineType, r.Routine.Schema, r.Routine.Name, w)))) {
 					Console.WriteLine(warning);
 				}
 			}

--- a/model/Database.cs
+++ b/model/Database.cs
@@ -50,6 +50,7 @@ namespace SchemaZen.model {
 		public const string SqlWhitespaceOrCommentRegex = @"(?>(?:\s+|--.*?(?:\r|\n)|/\*.*?\*/))";
 		public const string SqlEnclosedIdentifierRegex = @"\[.+?\]";
 		public const string SqlQuotedIdentifierRegex = "\".+?\"";
+		public const string SqlRegularIdentifierRegex = @"(?!\d)[\w@$#]+"; // see rules for regular identifiers here https://msdn.microsoft.com/en-us/library/ms175874.aspx
 
 		#region " Properties "
 

--- a/model/Database.cs
+++ b/model/Database.cs
@@ -320,40 +320,30 @@ namespace SchemaZen.model {
 			{
 				while (dr.Read())
 				{
-					// TODO: consider refactoring - it is bad practice to write to the console from a class library...
-					if (dr["definition"] is DBNull)
-					{
-						Console.ForegroundColor = ConsoleColor.Magenta;
-						Console.WriteLine("Warning: Unable to get definition for {0} {1}.{2}", (string)dr["type_desc"], (string)dr["schemaName"], (string)dr["routineName"]);
-						Console.ForegroundColor = ConsoleColor.White;
-					}
-					else
-					{
-						var r = new Routine((string)dr["schemaName"], (string)dr["routineName"]);
-						r.Text = (string)dr["definition"];
-						r.AnsiNull = (bool)dr["uses_ansi_nulls"];
-						r.QuotedId = (bool)dr["uses_quoted_identifier"];
-						Routines.Add(r);
+					var r = new Routine((string)dr["schemaName"], (string)dr["routineName"]);
+					r.Text = dr["definition"] is DBNull ? string.Empty : (string)dr["definition"];
+					r.AnsiNull = (bool)dr["uses_ansi_nulls"];
+					r.QuotedId = (bool)dr["uses_quoted_identifier"];
+					Routines.Add(r);
 
-						switch ((string)dr["type_desc"])
-						{
-							case "SQL_STORED_PROCEDURE":
-								r.RoutineType = Routine.RoutineKind.Procedure;
-								break;
-							case "SQL_TRIGGER":
-								r.RoutineType = Routine.RoutineKind.Trigger;
-								r.RelatedTableName = (string)dr["tableName"];
-								r.RelatedTableSchema = (string)dr["tableSchema"];
-								r.Disabled = (bool)dr["trigger_disabled"];
-								break;
-							case "SQL_SCALAR_FUNCTION":
-							case "SQL_INLINE_TABLE_VALUED_FUNCTION":
-								r.RoutineType = Routine.RoutineKind.Function;
-								break;
-							case "VIEW":
-								r.RoutineType = Routine.RoutineKind.View;
-								break;
-						}
+					switch ((string)dr["type_desc"])
+					{
+						case "SQL_STORED_PROCEDURE":
+							r.RoutineType = Routine.RoutineKind.Procedure;
+							break;
+						case "SQL_TRIGGER":
+							r.RoutineType = Routine.RoutineKind.Trigger;
+							r.RelatedTableName = (string)dr["tableName"];
+							r.RelatedTableSchema = (string)dr["tableSchema"];
+							r.Disabled = (bool)dr["trigger_disabled"];
+							break;
+						case "SQL_SCALAR_FUNCTION":
+						case "SQL_INLINE_TABLE_VALUED_FUNCTION":
+							r.RoutineType = Routine.RoutineKind.Function;
+							break;
+						case "VIEW":
+							r.RoutineType = Routine.RoutineKind.View;
+							break;
 					}
 				}
 			}

--- a/model/Database.cs
+++ b/model/Database.cs
@@ -305,12 +305,15 @@ namespace SchemaZen.model {
 						m.definition,
 						m.uses_ansi_nulls,
 						m.uses_quoted_identifier,
-						t.name as tableName
+						s2.name as tableSchema,
+						t.name as tableName,
+						tr.is_disabled as trigger_disabled
 					from sys.sql_modules m
 						inner join sys.objects o on m.object_id = o.object_id
 						inner join sys.schemas s on s.schema_id = o.schema_id
 						left join sys.triggers tr on m.object_id = tr.object_id
 						left join sys.tables t on tr.parent_id = t.object_id
+						left join sys.schemas s2 on s2.schema_id = t.schema_id
 					where objectproperty(o.object_id, 'IsMSShipped') = 0
 					";
 			using (SqlDataReader dr = cm.ExecuteReader())
@@ -339,6 +342,9 @@ namespace SchemaZen.model {
 								break;
 							case "SQL_TRIGGER":
 								r.RoutineType = Routine.RoutineKind.Trigger;
+								r.RelatedTableName = (string)dr["tableName"];
+								r.RelatedTableSchema = (string)dr["tableSchema"];
+								r.Disabled = (bool)dr["trigger_disabled"];
 								break;
 							case "SQL_SCALAR_FUNCTION":
 							case "SQL_INLINE_TABLE_VALUED_FUNCTION":

--- a/model/DbProperty.cs
+++ b/model/DbProperty.cs
@@ -1,7 +1,5 @@
 ﻿namespace SchemaZen.model {
 	public class DbProp {
-		public Database _db;
-
 		public DbProp(string name, string value) {
 			Name = name;
 			Value = value;
@@ -13,16 +11,13 @@
 		public string Script() {
 			switch (Name.ToUpper()) {
 				case "COLLATE":
-					if (string.IsNullOrEmpty(Value)) return "";
-					return string.Format("EXEC('ALTER DATABASE [' + @DB + '] COLLATE {0}')", Value);
+					return string.IsNullOrEmpty(Value) ? string.Empty : string.Format("EXEC('ALTER DATABASE [' + @DB + '] COLLATE {0}')", Value);
 
 				case "COMPATIBILITY_LEVEL":
-					if (string.IsNullOrEmpty(Value)) return "";
-					return string.Format("EXEC dbo.sp_dbcmptlevel @DB, {0}", Value);
+					return string.IsNullOrEmpty(Value) ? string.Empty : string.Format("EXEC dbo.sp_dbcmptlevel @DB, {0}", Value);
 
 				default:
-					if (string.IsNullOrEmpty(Value)) return "";
-					return string.Format("EXEC('ALTER DATABASE [' + @DB + '] SET {0} {1}')", Name, Value);
+					return string.IsNullOrEmpty(Value) ? string.Empty : string.Format("EXEC('ALTER DATABASE [' + @DB + '] SET {0} {1}')", Name, Value);
 			}
 		}
 	}

--- a/model/Routine.cs
+++ b/model/Routine.cs
@@ -104,20 +104,25 @@ namespace SchemaZen.model {
 		}
 
 		public IEnumerable<string> Warnings () {
-			// check if the name is correct
-			var regex = new Regex(string.Format(SqlCreateWithNameRegex, GetSQLTypeForRegEx()), RegexOptions.IgnoreCase | RegexOptions.Singleline);
-			var match = regex.Match(Text);
+			if (string.IsNullOrEmpty(Text)) {
+				yield return "Script definition could not be retrieved.";
+			} else {
 
-			// the schema is captured in group index 2, and the name in 3
+				// check if the name is correct
+				var regex = new Regex(string.Format(SqlCreateWithNameRegex, GetSQLTypeForRegEx()), RegexOptions.IgnoreCase | RegexOptions.Singleline);
+				var match = regex.Match(Text);
 
-			var nameGroup = match.Groups[3];
-			if (nameGroup.Success) {
-				var name = nameGroup.Value;
-				if (name.StartsWith("[") && name.EndsWith("]"))
-					name = name.Substring(1, name.Length - 2);
+				// the schema is captured in group index 2, and the name in 3
 
-				if (string.Compare(Name, name, StringComparison.InvariantCultureIgnoreCase) != 0) {
-					yield return string.Format("Name from script definition '{0}' does not match expected name '{1}'", name, Name);
+				var nameGroup = match.Groups[3];
+				if (nameGroup.Success) {
+					var name = nameGroup.Value;
+					if (name.StartsWith("[") && name.EndsWith("]"))
+						name = name.Substring(1, name.Length - 2);
+
+					if (string.Compare(Name, name, StringComparison.InvariantCultureIgnoreCase) != 0) {
+						yield return string.Format("Name from script definition '{0}' does not match expected name '{1}'", name, Name);
+					}
 				}
 			}
 		} 

--- a/model/Routine.cs
+++ b/model/Routine.cs
@@ -58,11 +58,14 @@ namespace SchemaZen.model {
 		{
 			var before = ScriptQuotedIdAndAnsiNulls(db, false);
 			var after = ScriptQuotedIdAndAnsiNulls(db, true);
-			if (after != string.Empty)
+			if (!string.IsNullOrEmpty(after))
 				after = Environment.NewLine + "GO" + Environment.NewLine + after;
 
 			if (RoutineType == RoutineKind.Trigger)
 				after += string.Format("{0} TRIGGER [{1}].[{2}] ON [{3}].[{4}]", Disabled ? "DISABLE" : "ENABLE", Schema, Name, RelatedTableSchema, RelatedTableName) + Environment.NewLine + "GO" + Environment.NewLine;
+
+			if (string.IsNullOrEmpty(definition))
+				definition = string.Format("/* missing definition for {0} [{1}].[{2}] */", RoutineType, Schema, Name);
 
 			return before + definition + after;
 		}

--- a/model/Routine.cs
+++ b/model/Routine.cs
@@ -20,6 +20,9 @@ namespace SchemaZen.model {
 		public RoutineKind RoutineType;
 		public string Schema;
 		public string Text;
+		public bool Disabled;
+		public string RelatedTableSchema;
+		public string RelatedTableName;
 
 		private const string SqlCreateRegex = @"\A" + Database.SqlWhitespaceOrCommentRegex + @"*?(CREATE)" + Database.SqlWhitespaceOrCommentRegex;
 		private const string SqlCreateWithNameRegex = SqlCreateRegex + @"+{0}" + Database.SqlWhitespaceOrCommentRegex + @"+?(?:(?:(" + Database.SqlEnclosedIdentifierRegex + @"|" + Database.SqlRegularIdentifierRegex + @")\.)?(" + Database.SqlEnclosedIdentifierRegex + @"|" + Database.SqlRegularIdentifierRegex + @"))(?:\(|" + Database.SqlWhitespaceOrCommentRegex + @")";
@@ -57,7 +60,10 @@ namespace SchemaZen.model {
 			var after = ScriptQuotedIdAndAnsiNulls(db, true);
 			if (after != string.Empty)
 				after = Environment.NewLine + "GO" + Environment.NewLine + after;
-			
+
+			if (RoutineType == RoutineKind.Trigger)
+				after += string.Format("{0} TRIGGER [{1}].[{2}] ON [{3}].[{4}]", Disabled ? "DISABLE" : "ENABLE", Schema, Name, RelatedTableSchema, RelatedTableName) + Environment.NewLine + "GO" + Environment.NewLine;
+
 			return before + definition + after;
 		}
 

--- a/model/Routine.cs
+++ b/model/Routine.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text.RegularExpressions;
 
@@ -20,7 +22,7 @@ namespace SchemaZen.model {
 		public string Text;
 
 		private const string SqlCreateRegex = @"\A" + Database.SqlWhitespaceOrCommentRegex + @"*?(CREATE)" + Database.SqlWhitespaceOrCommentRegex;
-		private const string SqlCreateWithNameRegex = SqlCreateRegex + @"+{0}" + Database.SqlWhitespaceOrCommentRegex + @"+?(" + Database.SqlEnclosedIdentifierRegex + @"\." + Database.SqlEnclosedIdentifierRegex + @"|" + Database.SqlEnclosedIdentifierRegex + @"|\S+)(?:\(|" + Database.SqlWhitespaceOrCommentRegex + @")";
+		private const string SqlCreateWithNameRegex = SqlCreateRegex + @"+{0}" + Database.SqlWhitespaceOrCommentRegex + @"+?(?:(?:(" + Database.SqlEnclosedIdentifierRegex + @"|" + Database.SqlRegularIdentifierRegex + @")\.)?(" + Database.SqlEnclosedIdentifierRegex + @"|" + Database.SqlRegularIdentifierRegex + @"))(?:\(|" + Database.SqlWhitespaceOrCommentRegex + @")";
 
 		public Routine(string schema, string name) {
 			Schema = schema;
@@ -94,5 +96,24 @@ namespace SchemaZen.model {
 			}
 			throw new Exception(string.Format("Unable to script routine {0} {1}.{2} as ALTER", RoutineType, Schema, Name));
 		}
+
+		public IEnumerable<string> Warnings () {
+			// check if the name is correct
+			var regex = new Regex(string.Format(SqlCreateWithNameRegex, GetSQLTypeForRegEx()), RegexOptions.IgnoreCase | RegexOptions.Singleline);
+			var match = regex.Match(Text);
+
+			// the schema is captured in group index 2, and the name in 3
+
+			var nameGroup = match.Groups[3];
+			if (nameGroup.Success) {
+				var name = nameGroup.Value;
+				if (name.StartsWith("[") && name.EndsWith("]"))
+					name = name.Substring(1, name.Length - 2);
+
+				if (string.Compare(Name, name, StringComparison.InvariantCultureIgnoreCase) != 0) {
+					yield return string.Format("Name from script definition '{0}' does not match expected name '{1}'", name, Name);
+				}
+			}
+		} 
 	}
 }

--- a/test/FunctionTester.cs
+++ b/test/FunctionTester.cs
@@ -1,23 +1,48 @@
 ﻿using System;
+using System.Linq;
 using NUnit.Framework;
 using SchemaZen.model;
 
 namespace SchemaZen.test {
 	[TestFixture]
 	public class FunctionTester {
-		[Test]
-		public void TestScript() {
-			var f = new Routine("dbo", "udf_GetDate");
-			f.Text = @"
-CREATE FUNCTION [dbo].[udf_GetDate]()
+		private const string ExampleFunc = @"
+CREATE FUNCTION [dbo].udf_GetDate()
 RETURNS DATETIME AS
 BEGIN
 	RETURN GETDATE()
 END
 ";
+
+		[Test]
+		public void TestScript() {
+			var f = new Routine("dbo", "udf_GetDate") {
+														  RoutineType = Routine.RoutineKind.Function,
+														  Text = ExampleFunc
+													  };
 			Console.WriteLine(f.ScriptCreate(null));
 			TestHelper.ExecBatchSql(f.ScriptCreate(null) + "\nGO", "");
 			TestHelper.ExecSql("drop function [dbo].[udf_GetDate]", "");
+		}
+
+		[Test]
+		public void TestScriptNoWarnings()
+		{
+			var f = new Routine("dbo", "udf_GetDate") {
+														  Text = ExampleFunc,
+														  RoutineType = Routine.RoutineKind.Function
+													  };
+			Assert.IsFalse(f.Warnings().Any());
+		}
+
+		[Test]
+		public void TestScriptWarnings()
+		{
+			var f = new Routine("dbo", "udf_GetDate2") {
+														   Text = ExampleFunc,
+														   RoutineType = Routine.RoutineKind.Function
+													   };
+			Assert.IsTrue(f.Warnings().Any());
 		}
 	}
 }


### PR DESCRIPTION
I've fixed issue #38 and also (re-)added a warning when a routine name differs from the definition.  As per our previous discussion, it won't attempt to fix it automatically - it will just warn the user. (And I fixed the previous bug that meant it would include parenthesis in the name it extracts from the definition in some situations.)