### PR TITLE
Foreign keys with same name cause exception

### DIFF
--- a/model/ForeignKey.cs
+++ b/model/ForeignKey.cs
@@ -41,7 +41,7 @@ namespace SchemaZen.model {
 		private void AssertArgNotNull(object arg, string argName) {
 			if (arg == null) {
 				throw new ArgumentNullException(string.Format(
-					"Unable to Script FK {0}. {1} must not be null.", Name, argName));
+					"Unable to Script FK {0} on table {1}.{2}. {3} must not be null.", Name, Table.Owner, Table.Name, argName));
 			}
 		}
 

--- a/test/ForeignKeyTester.cs
+++ b/test/ForeignKeyTester.cs
@@ -25,10 +25,10 @@ namespace SchemaZen.test {
 			db.ExecCreate(true);
 			db.Load();
 
-			Assert.AreEqual("c3", db.FindForeignKey("fk_test").Columns[0]);
-			Assert.AreEqual("c2", db.FindForeignKey("fk_test").Columns[1]);
-			Assert.AreEqual("c1", db.FindForeignKey("fk_test").RefColumns[0]);
-			Assert.AreEqual("c2", db.FindForeignKey("fk_test").RefColumns[1]);
+			Assert.AreEqual("c3", db.FindForeignKey("fk_test", "dbo").Columns[0]);
+			Assert.AreEqual("c2", db.FindForeignKey("fk_test", "dbo").Columns[1]);
+			Assert.AreEqual("c1", db.FindForeignKey("fk_test", "dbo").RefColumns[0]);
+			Assert.AreEqual("c2", db.FindForeignKey("fk_test", "dbo").RefColumns[1]);
 
 			db.ExecCreate(true);
 		}


### PR DESCRIPTION
SQL Server allows foreign keys to have the same name if the tables are in different schemas. Schemazen cannot handle this in v1.3.

I have committed a red test in one commit so you can see the issue by running the tests.

The fix then brings the tests back to green. I have essentially associated the foreign key to the schema on which the table is defined.

Dan