### PR TITLE
"Instead of" trigger on a view causes exception

### DIFF
--- a/model/Database.cs
+++ b/model/Database.cs
@@ -286,15 +286,17 @@ namespace SchemaZen.model {
 						m.definition,
 						m.uses_ansi_nulls,
 						m.uses_quoted_identifier,
-						s2.name as tableSchema,
-						t.name as tableName,
+						isnull(s2.name, s3.name) as tableSchema,
+						isnull(t.name, v.name) as tableName,
 						tr.is_disabled as trigger_disabled
 					from sys.sql_modules m
 						inner join sys.objects o on m.object_id = o.object_id
 						inner join sys.schemas s on s.schema_id = o.schema_id
 						left join sys.triggers tr on m.object_id = tr.object_id
 						left join sys.tables t on tr.parent_id = t.object_id
+						left join sys.views v on tr.parent_id = v.object_id
 						left join sys.schemas s2 on s2.schema_id = t.schema_id
+						left join sys.schemas s3 on s3.schema_id = v.schema_id
 					where objectproperty(o.object_id, 'IsMSShipped') = 0
 					";
 			using (var dr = cm.ExecuteReader()) {

--- a/test/DatabaseTester.cs
+++ b/test/DatabaseTester.cs
@@ -181,6 +181,55 @@ namespace SchemaZen.test {
 		}
 
 		[Test]
+        public void TestScriptViewInsteadOfTrigger()
+        {
+            var setupSQL1 = @"
+CREATE TABLE [dbo].[t1]
+(
+    a INT NOT NULL, 
+    CONSTRAINT [PK] PRIMARY KEY (a)
+)
+";
+            var setupSQL2 = @"
+
+CREATE VIEW [dbo].[v1] AS
+
+    SELECT * FROM t1
+
+";
+            var setupSQL3 = @"
+
+CREATE TRIGGER [dbo].[TR_v1] ON [dbo].[v1] INSTEAD OF DELETE AS
+
+    DELETE FROM [dbo].[t1] FROM [dbo].[t1] INNER JOIN DELETED ON DELETED.a = [dbo].[t1].a
+
+";
+
+            var db = new Database("TestScriptViewInsteadOfTrigger");
+
+            db.Connection = ConfigHelper.TestDB.Replace("database=TESTDB", "database=" + db.Name);
+
+            db.ExecCreate(true);
+
+            DBHelper.ExecSql(db.Connection, setupSQL1);
+            DBHelper.ExecSql(db.Connection, setupSQL2);
+            DBHelper.ExecSql(db.Connection, setupSQL3);
+
+            db.Dir = db.Name;
+            db.Load();
+
+            // Required in order to expose the exception
+            db.ScriptToDir();
+
+            var triggers = db.Routines.Where(x => x.RoutineType == Routine.RoutineKind.Trigger).ToList();
+
+            Assert.AreEqual(1, triggers.Count());
+            Assert.AreEqual("TR_v1", triggers[0].Name);
+            Assert.IsTrue(File.Exists(db.Name + "\\triggers\\TR_v1.sql"));
+
+        }
+
+		[Test]
 		public void TestScriptDeletedProc() {
 			var source = new Database();
 			source.Routines.Add(new Routine("dbo", "test", null));


### PR DESCRIPTION
SQL Server allows "instead of" triggers on views. Schemazen cannot handle this in v1.3.

I have committed a red test in one commit so you can see the issue by running the tests.

The fix then brings the tests back to green. I have left joined sys.views in the query to get all triggers so that the table schema and table name are no longer null (but are the view schema and view name.)

This appears to work, but I am concerned that having the view name as the tablename might not be ideal

Happy to attack from a different angle if you were to point me in the right direction.

Thanks!

Dan