### PR TITLE
Script user defined table types

### DIFF
--- a/model/Database.cs
+++ b/model/Database.cs
@@ -977,7 +977,8 @@ where name = @dbname
 			WritePropsScript();
 			WriteSchemaScript();
 			WriteScriptDir("tables", Tables.ToArray());
-			WriteScriptDir("foreign_keys", ForeignKeys.ToArray());
+            WriteScriptDir("table_types", TableTypes.ToArray());
+            WriteScriptDir("foreign_keys", ForeignKeys.ToArray());
 			foreach (var routineType in Routines.GroupBy(x => x.RoutineType)) {
 				var dir = routineType.Key.ToString().ToLower() + "s";
 				WriteScriptDir(dir, routineType.ToArray());

--- a/model/Database.cs
+++ b/model/Database.cs
@@ -417,6 +417,9 @@ order by fk.name, fkc.constraint_column_id
 						union
 						select object_id, name, schema_id, 'V' as baseType
 						from   sys.views
+						union
+						select type_table_object_id, name, schema_id, 'TVT' as baseType
+						from   sys.table_types
 						) t
 						inner join sys.indexes i on i.object_id = t.object_id
 						inner join sys.index_columns ic on ic.object_id = t.object_id
@@ -430,7 +433,7 @@ order by fk.name, fkc.constraint_column_id
 				while (dr.Read()) {
 					var t = (string) dr["baseType"] == "V"
 						? new Table((string) dr["schemaName"], (string) dr["tableName"])
-						: FindTable((string) dr["tableName"], (string) dr["schemaName"]);
+						: FindTable((string) dr["tableName"], (string) dr["schemaName"], ((string) dr["baseType"]) == "TVT");
 					var c = t.FindConstraint((string) dr["indexName"]);
 					if (c == null) {
 						c = new Constraint((string) dr["indexName"], "", "");

--- a/model/Database.cs
+++ b/model/Database.cs
@@ -563,7 +563,7 @@ order by fk.name, fkc.constraint_column_id
 					t.name as DATA_TYPE,
 					c.column_id as ORDINAL_POSITION,
 					CASE WHEN c.is_nullable = 1 THEN 'YES' ELSE 'NO' END as IS_NULLABLE,
-					CAST(c.max_length as int) as CHARACTER_MAXIMUM_LENGTH,
+					CASE WHEN t.name = 'nvarchar' THEN CAST(c.max_length as int)/2 ELSE CAST(c.max_length as int) END as CHARACTER_MAXIMUM_LENGTH,
 					c.precision as NUMERIC_PRECISION,
 					c.scale as NUMERIC_SCALE,
 					CASE WHEN c.is_rowguidcol = 1 THEN 'YES' ELSE 'NO' END as IS_ROW_GUID_COL

--- a/test/DatabaseTester.cs
+++ b/test/DatabaseTester.cs
@@ -180,6 +180,36 @@ namespace SchemaZen.test {
 			}
 		}
 
+        [Test]
+        public void TestScriptTableType()
+        {
+            var setupSQL1 = @"
+CREATE TYPE [dbo].[MyTableType] AS TABLE(
+	[ID] [nvarchar](250) NULL
+)
+
+";
+
+            var db = new Database("TestScriptTableType");
+
+            db.Connection = ConfigHelper.TestDB.Replace("database=TESTDB", "database=" + db.Name);
+
+            db.ExecCreate(true);
+
+            DBHelper.ExecSql(db.Connection, setupSQL1);
+
+            db.Dir = db.Name;
+            db.Load();
+
+            db.ScriptToDir();
+
+            Assert.AreEqual(1, db.TableTypes.Count());
+            Assert.AreEqual(250, db.TableTypes[0].Columns.Items[0].Length);
+            Assert.AreEqual("MyTableType", db.TableTypes[0].Name);
+            Assert.IsTrue(File.Exists(db.Name + "\\table_types\\TYPE_MyTableType.sql"));
+
+        }
+
 		[Test]
 		public void TestScriptDeletedProc() {
 			var source = new Database();

--- a/test/DatabaseTester.cs
+++ b/test/DatabaseTester.cs
@@ -210,6 +210,46 @@ CREATE TYPE [dbo].[MyTableType] AS TABLE(
 
         }
 
+
+        [Test]
+        public void TestScriptTableTypePrimaryKey()
+        {
+            var setupSQL1 = @"
+CREATE TYPE [dbo].[MyTableType] AS TABLE(
+	[ID] [int] NOT NULL,
+	[Value] [varchar](50) NOT NULL,
+	PRIMARY KEY CLUSTERED 
+(
+	[ID] ASC
+)
+)
+
+";
+
+            var db = new Database("TestScriptTableTypePrimaryKey");
+
+            db.Connection = ConfigHelper.TestDB.Replace("database=TESTDB", "database=" + db.Name);
+
+            db.ExecCreate(true);
+
+            DBHelper.ExecSql(db.Connection, setupSQL1);
+
+            db.Dir = db.Name;
+            db.Load();
+
+            db.ScriptToDir();
+
+            Assert.AreEqual(1, db.TableTypes.Count());
+            Assert.AreEqual(1, db.TableTypes[0].PrimaryKey.Columns.Count);
+            Assert.AreEqual("ID", db.TableTypes[0].PrimaryKey.Columns[0]);
+            Assert.AreEqual(50, db.TableTypes[0].Columns.Items[1].Length);
+            Assert.AreEqual("MyTableType", db.TableTypes[0].Name);
+            Assert.IsTrue(File.Exists(db.Name + "\\table_types\\TYPE_MyTableType.sql"));
+
+            Assert.IsTrue(File.ReadAllText(db.Name + "\\table_types\\TYPE_MyTableType.sql").Contains("PRIMARY KEY"));
+
+        }
+
 		[Test]
 		public void TestScriptDeletedProc() {
 			var source = new Database();


### PR DESCRIPTION
Hi

I came across this issue #23 and this commit 6a1069b78f22429b608e1ce076654cbacf7838fd and I need user defined table types to be scripted, so I've had a go at getting this up to scratch.

I have:

* Fixed a bug with nvarchar columns in table types having a length 2x what it should be
* Added support for the scripting of primary keys for user defined table types
* Switched on the writing of table type scripts to the script directory

I have run this on one of my databases with 10 user defined table types and it now scripts them them correctly and the rest of my database scripts as it did before these commits.

If you'd like me to change anything, please let me know!

Thanks

Dan

