### PR TITLE
fix creating data folder when no data is exported

### DIFF
--- a/model/Database.cs
+++ b/model/Database.cs
@@ -142,6 +142,7 @@ namespace SchemaZen.model {
 			Tables.Clear();
 			Routines.Clear();
 			ForeignKeys.Clear();
+			DataTables.Clear();
 			ViewIndexes.Clear();
 			Assemblies.Clear();
 			Users.Clear();

--- a/model/Database.cs
+++ b/model/Database.cs
@@ -1067,6 +1067,8 @@ where name = @dbname
 		}
 
 		public void ExportData(string tableHint = null, Action<TraceLevel, string> log = null) {
+			if (!DataTables.Any())
+				return;
 			var dataDir = Dir + "/data";
 			if (!Directory.Exists(dataDir)) {
 				Directory.CreateDirectory(dataDir);
@@ -1100,12 +1102,13 @@ where name = @dbname
 		#region Create
 
 		public void ImportData(Action<TraceLevel, string> log = null) {
+			if (log == null) log = (tl, s) => { };
+
 			var dataDir = Dir + "\\data";
 			if (!Directory.Exists(dataDir)) {
+				log(TraceLevel.Verbose, "No data to import.");
 				return;
 			}
-
-			if (log == null) log = (tl, s) => { };
 
 			log(TraceLevel.Verbose, "Loading database schema...");
 			Load(); // load the schema first so we can import data

--- a/model/Database.cs
+++ b/model/Database.cs
@@ -142,7 +142,6 @@ namespace SchemaZen.model {
 			Tables.Clear();
 			Routines.Clear();
 			ForeignKeys.Clear();
-			DataTables.Clear();
 			ViewIndexes.Clear();
 			Assemblies.Clear();
 			Users.Clear();

--- a/test/DatabaseTester.cs
+++ b/test/DatabaseTester.cs
@@ -484,6 +484,11 @@ select * from Table1
 			db.Dir = db.Name;
 			db.Load();
 
+			if (Directory.Exists(db.Dir)) // if the directory exists, delete it to make it a fair test
+			{
+				Directory.Delete(db.Dir, true);
+			}
+
 			db.ScriptToDir();
 
 			Assert.AreEqual(0, db.Assemblies.Count);

--- a/test/DatabaseTester.cs
+++ b/test/DatabaseTester.cs
@@ -471,5 +471,48 @@ select * from Table1
 			copy.Load();
 			TestCompare(db, copy);
 		}
+
+		[Test]
+		public void TestScriptToDirOnlyCreatesNecessaryFolders()
+		{
+			var db = new Database("TestEmptyDB");
+
+			db.Connection = ConfigHelper.TestDB.Replace("database=TESTDB", "database=" + db.Name);
+
+			db.ExecCreate(true);
+
+			db.Dir = db.Name;
+			db.Load();
+
+			db.ScriptToDir();
+
+			Assert.AreEqual(0, db.Assemblies.Count);
+			Assert.AreEqual(0, db.DataTables.Count);
+			Assert.AreEqual(0, db.ForeignKeys.Count);
+			Assert.AreEqual(0, db.Routines.Count);
+			Assert.AreEqual(0, db.Schemas.Count);
+			Assert.AreEqual(0, db.Synonyms.Count);
+			Assert.AreEqual(0, db.Tables.Count);
+			Assert.AreEqual(0, db.TableTypes.Count);
+			Assert.AreEqual(0, db.Users.Count);
+			Assert.AreEqual(0, db.ViewIndexes.Count);
+
+			Assert.IsTrue(Directory.Exists(db.Name));
+			Assert.IsTrue(File.Exists(db.Name + "\\props.sql"));
+			//Assert.IsFalse(File.Exists(db.Name + "\\schemas.sql"));
+
+			Assert.IsFalse(Directory.Exists(db.Name + "\\assemblies"));
+			Assert.IsFalse(Directory.Exists(db.Name + "\\data"));
+			Assert.IsFalse(Directory.Exists(db.Name + "\\foreign_keys"));
+			foreach (var routineType in Enum.GetNames(typeof(Routine.RoutineKind)))
+			{
+				var dir = routineType.ToLower() + "s";
+				Assert.IsFalse(Directory.Exists(db.Name + "\\" + dir));
+			}
+			Assert.IsFalse(Directory.Exists(db.Name + "\\synonyms"));
+			Assert.IsFalse(Directory.Exists(db.Name + "\\tables"));
+			Assert.IsFalse(Directory.Exists(db.Name + "\\table_types"));
+			Assert.IsFalse(Directory.Exists(db.Name + "\\users"));
+		}
 	}
 }


### PR DESCRIPTION
Hi Seth,

I have added a test to prove that there are no regressions to issue #38 ("don't create empty folders"), which is red.
I have then made a fix, by not creating the data folder unless there are DataTables to export, which turns this failing test back to green.