### PR TITLE
Numeric col in table type

### DIFF
--- a/model/Database.cs
+++ b/model/Database.cs
@@ -573,7 +573,7 @@ order by fk.name, fkc.constraint_column_id
 					CASE WHEN c.is_nullable = 1 THEN 'YES' ELSE 'NO' END as IS_NULLABLE,
 					CASE WHEN t.name = 'nvarchar' THEN CAST(c.max_length as int)/2 ELSE CAST(c.max_length as int) END as CHARACTER_MAXIMUM_LENGTH,
 					c.precision as NUMERIC_PRECISION,
-					c.scale as NUMERIC_SCALE,
+					CAST(c.scale as int) as NUMERIC_SCALE,
 					CASE WHEN c.is_rowguidcol = 1 THEN 'YES' ELSE 'NO' END as IS_ROW_GUID_COL
 				from sys.columns c
 					inner join sys.table_types tt

--- a/test/DatabaseTester.cs
+++ b/test/DatabaseTester.cs
@@ -184,7 +184,8 @@ namespace SchemaZen.test {
 		public void TestScriptTableType() {
 			var setupSQL1 = @"
 CREATE TYPE [dbo].[MyTableType] AS TABLE(
-	[ID] [nvarchar](250) NULL
+	[ID] [nvarchar](250) NULL,
+	[Value] [numeric](5, 1) NULL
 )
 
 ";
@@ -204,6 +205,8 @@ CREATE TYPE [dbo].[MyTableType] AS TABLE(
 
 			Assert.AreEqual(1, db.TableTypes.Count());
 			Assert.AreEqual(250, db.TableTypes[0].Columns.Items[0].Length);
+			Assert.AreEqual(1, db.TableTypes[0].Columns.Items[1].Scale);
+			Assert.AreEqual(5, db.TableTypes[0].Columns.Items[1].Precision);
 			Assert.AreEqual("MyTableType", db.TableTypes[0].Name);
 			Assert.IsTrue(File.Exists(db.Name + "\\table_types\\TYPE_MyTableType.sql"));
 


### PR DESCRIPTION
Hi Seth,

I have modified a test for scripting a user defined table type to prove that scripting numeric columns in table types works properly.  At the moment, the test fails. This relates to issue #55.
I have then made a fix, by casting the `tinyint` scale column to an `int`, which turns this failing test back to green.
