### PR TITLE
Table types and constraints

### DIFF
--- a/model/Constraint.cs
+++ b/model/Constraint.cs
@@ -36,8 +36,8 @@ namespace SchemaZen.model {
 				}
 				return sql;
 			}
-			return string.Format("CONSTRAINT [{0}] {1} {2} ([{3}])", Name, Type, ClusteredText,
-				string.Join("], [", Columns.ToArray()));
+			return (Table.IsType ? string.Empty : string.Format("CONSTRAINT [{0}] ", Name)) +
+				string.Format("{0} {1} ([{2}])", Type, ClusteredText, string.Join("], [", Columns.ToArray()));
 		}
 	}
 }

--- a/model/Constraint.cs
+++ b/model/Constraint.cs
@@ -23,7 +23,7 @@ namespace SchemaZen.model {
 		}
 
 		public string UniqueText {
-			get { return !Unique ? "" : "UNIQUE"; }
+			get { return Type != "PRIMARY KEY" && !Unique ? "" : "UNIQUE"; }
 		}
 
 		public string ScriptCreate() {

--- a/model/Database.cs
+++ b/model/Database.cs
@@ -140,6 +140,7 @@ namespace SchemaZen.model {
 
 		public void Load() {
 			Tables.Clear();
+			TableTypes.Clear();
 			Routines.Clear();
 			ForeignKeys.Clear();
 			DataTables.Clear();

--- a/model/Database.cs
+++ b/model/Database.cs
@@ -121,7 +121,7 @@ namespace SchemaZen.model {
 
 		private static readonly string[] dirs = {
 			"tables", "foreign_keys", "assemblies", "functions", "procedures", "triggers",
-			"views", "xmlschemacollections", "data", "users", "synonyms"
+			"views", "xmlschemacollections", "data", "users", "synonyms", "table_types"
 		};
 
 		private void SetPropOnOff(string propName, object dbVal) {
@@ -442,8 +442,7 @@ order by fk.name, fkc.constraint_column_id
 					var c = t.FindConstraint((string) dr["indexName"]);
 					if (c == null) {
 						c = new Constraint((string) dr["indexName"], "", "");
-						t.Constraints.Add(c);
-						c.Table = t;
+						t.AddConstraint(c);
 
 						if ((string) dr["baseType"] == "V")
 							ViewIndexes.Add(c);

--- a/test/DatabaseTester.cs
+++ b/test/DatabaseTester.cs
@@ -148,16 +148,16 @@ namespace SchemaZen.test {
 			var t1 = new Table("dbo", "t1");
 			t1.Columns.Add(new Column("col1", "int", false, null) {Position = 1});
 			t1.Columns.Add(new Column("col2", "int", false, null) {Position = 2});
-			t1.Constraints.Add(new Constraint("pk_t1", "PRIMARY KEY", "col1,col2"));
+			t1.AddConstraint(new Constraint("pk_t1", "PRIMARY KEY", "col1,col2"));
 			t1.FindConstraint("pk_t1").Clustered = true;
 
 			var t2 = new Table("dbo", "t2");
 			t2.Columns.Add(new Column("col1", "int", false, null) {Position = 1});
 			t2.Columns.Add(new Column("col2", "int", false, null) {Position = 2});
 			t2.Columns.Add(new Column("col3", "int", false, null) {Position = 3});
-			t2.Constraints.Add(new Constraint("pk_t2", "PRIMARY KEY", "col1"));
+			t2.AddConstraint(new Constraint("pk_t2", "PRIMARY KEY", "col1"));
 			t2.FindConstraint("pk_t2").Clustered = true;
-			t2.Constraints.Add(new Constraint("IX_col3", "UNIQUE", "col3"));
+			t2.AddConstraint(new Constraint("IX_col3", "UNIQUE", "col3"));
 
 			db.ForeignKeys.Add(new ForeignKey(t2, "fk_t2_t1", "col2,col3", t1, "col1,col2"));
 
@@ -372,26 +372,21 @@ select * from Table1
 			var policy = new Table("dbo", "Policy");
 			policy.Columns.Add(new Column("id", "int", false, null) {Position = 1});
 			policy.Columns.Add(new Column("form", "tinyint", false, null) {Position = 2});
-			policy.Constraints.Add(new Constraint("PK_Policy", "PRIMARY KEY", "id"));
-			policy.Constraints[0].Clustered = true;
-			policy.Constraints[0].Unique = true;
+			policy.AddConstraint(new Constraint("PK_Policy", "PRIMARY KEY", "id") { Clustered = true, Unique = true });
 			policy.Columns.Items[0].Identity = new Identity(1, 1);
 
 			var loc = new Table("dbo", "Location");
 			loc.Columns.Add(new Column("id", "int", false, null) {Position = 1});
 			loc.Columns.Add(new Column("policyId", "int", false, null) {Position = 2});
 			loc.Columns.Add(new Column("storage", "bit", false, null) {Position = 3});
-			loc.Constraints.Add(new Constraint("PK_Location", "PRIMARY KEY", "id"));
-			loc.Constraints[0].Clustered = true;
-			loc.Constraints[0].Unique = true;
+			loc.AddConstraint(new Constraint("PK_Location", "PRIMARY KEY", "id") { Clustered = true, Unique = true });
 			loc.Columns.Items[0].Identity = new Identity(1, 1);
 
 			var formType = new Table("dbo", "FormType");
 			formType.Columns.Add(new Column("code", "tinyint", false, null) {Position = 1});
 			formType.Columns.Add(new Column("desc", "varchar", 10, false, null) {Position = 2});
-			formType.Constraints.Add(new Constraint("PK_FormType", "PRIMARY KEY", "code"));
-			formType.Constraints[0].Clustered = true;
-
+			formType.AddConstraint(new Constraint("PK_FormType", "PRIMARY KEY", "code") { Clustered = true });
+			
 			var fk_policy_formType = new ForeignKey("FK_Policy_FormType");
 			fk_policy_formType.Table = policy;
 			fk_policy_formType.Columns.Add("form");
@@ -412,7 +407,7 @@ select * from Table1
 			tt_codedesc.IsType = true;
 			tt_codedesc.Columns.Add(new Column("code", "tinyint", false, null) { Position = 1 });
 			tt_codedesc.Columns.Add(new Column("desc", "varchar", 10, false, null) { Position = 2 });
-			tt_codedesc.Constraints.Add(new Constraint("PK_CodeDesc", "PRIMARY KEY", "code"));
+			tt_codedesc.AddConstraint(new Constraint("PK_CodeDesc", "PRIMARY KEY", "code"));
 
 			var db = new Database("ScriptToDirTest");
 			db.Tables.Add(policy);

--- a/test/DatabaseTester.cs
+++ b/test/DatabaseTester.cs
@@ -408,10 +408,17 @@ select * from Table1
 			fk_location_policy.OnUpdate = "NO ACTION";
 			fk_location_policy.OnDelete = "CASCADE";
 
+			var tt_codedesc = new Table("dbo", "CodeDesc");
+			tt_codedesc.IsType = true;
+			tt_codedesc.Columns.Add(new Column("code", "tinyint", false, null) { Position = 1 });
+			tt_codedesc.Columns.Add(new Column("desc", "varchar", 10, false, null) { Position = 2 });
+			tt_codedesc.Constraints.Add(new Constraint("PK_CodeDesc", "PRIMARY KEY", "code"));
+
 			var db = new Database("ScriptToDirTest");
 			db.Tables.Add(policy);
 			db.Tables.Add(formType);
 			db.Tables.Add(loc);
+			db.TableTypes.Add(tt_codedesc);
 			db.ForeignKeys.Add(fk_policy_formType);
 			db.ForeignKeys.Add(fk_location_policy);
 			db.FindProp("COMPATIBILITY_LEVEL").Value = "110";
@@ -451,6 +458,10 @@ select * from Table1
 
 			db.DataTables.Add(formType);
 			db.Dir = db.Name;
+
+			if (Directory.Exists(db.Dir))
+				Directory.Delete(db.Dir, true);
+
 			db.ScriptToDir();
 			Assert.IsTrue(Directory.Exists(db.Name));
 			Assert.IsTrue(Directory.Exists(db.Name + "\\data"));
@@ -462,6 +473,9 @@ select * from Table1
 			}
 			foreach (var t in db.Tables) {
 				Assert.IsTrue(File.Exists(db.Name + "\\tables\\" + t.Name + ".sql"));
+			}
+			foreach (var t in db.TableTypes) {
+				Assert.IsTrue(File.Exists(db.Name + "\\table_types\\TYPE_" + t.Name + ".sql"));
 			}
 			foreach (var expected in db.ForeignKeys.Select(fk => db.Name + "\\foreign_keys\\" + fk.Table.Name + ".sql")) {
 				Assert.IsTrue(File.Exists(expected), "File does not exist" + expected);

--- a/test/DatabaseTester.cs
+++ b/test/DatabaseTester.cs
@@ -385,7 +385,7 @@ select * from Table1
 			var formType = new Table("dbo", "FormType");
 			formType.Columns.Add(new Column("code", "tinyint", false, null) {Position = 1});
 			formType.Columns.Add(new Column("desc", "varchar", 10, false, null) {Position = 2});
-			formType.AddConstraint(new Constraint("PK_FormType", "PRIMARY KEY", "code") { Clustered = true });
+			formType.AddConstraint(new Constraint("PK_FormType", "PRIMARY KEY", "code") { Clustered = true, Unique = true });
 			
 			var fk_policy_formType = new ForeignKey("FK_Policy_FormType");
 			fk_policy_formType.Table = policy;

--- a/test/ForeignKeyTester.cs
+++ b/test/ForeignKeyTester.cs
@@ -8,7 +8,7 @@ namespace SchemaZen.test {
 			var t1 = new Table("dbo", "t1");
 			t1.Columns.Add(new Column("c2", "varchar", 10, false, null));
 			t1.Columns.Add(new Column("c1", "int", false, null));
-			t1.Constraints.Add(new Constraint("pk_t1", "PRIMARY KEY", "c1,c2"));
+			t1.AddConstraint(new Constraint("pk_t1", "PRIMARY KEY", "c1,c2"));
 
 			var t2 = new Table("dbo", "t2");
 			t2.Columns.Add(new Column("c1", "int", false, null));
@@ -39,7 +39,7 @@ namespace SchemaZen.test {
 			person.Columns.Add(new Column("id", "int", false, null));
 			person.Columns.Add(new Column("name", "varchar", 50, false, null));
 			person.Columns.Find("id").Identity = new Identity(1, 1);
-			person.Constraints.Add(new Constraint("PK_Person", "PRIMARY KEY", "id"));
+			person.AddConstraint(new Constraint("PK_Person", "PRIMARY KEY", "id"));
 
 			var address = new Table("dbo", "Address");
 			address.Columns.Add(new Column("id", "int", false, null));
@@ -49,7 +49,7 @@ namespace SchemaZen.test {
 			address.Columns.Add(new Column("state", "char", 2, false, null));
 			address.Columns.Add(new Column("zip", "varchar", 5, false, null));
 			address.Columns.Find("id").Identity = new Identity(1, 1);
-			address.Constraints.Add(new Constraint("PK_Address", "PRIMARY KEY", "id"));
+			address.AddConstraint(new Constraint("PK_Address", "PRIMARY KEY", "id"));
 
 			var fk = new ForeignKey(address, "FK_Address_Person", "personId", person, "id", "", "CASCADE");
 

--- a/test/ProcTester.cs
+++ b/test/ProcTester.cs
@@ -13,7 +13,7 @@ namespace SchemaZen.test {
 			t.Columns.Add(new Column("city", "varchar", 50, false, null));
 			t.Columns.Add(new Column("state", "char", 2, false, null));
 			t.Columns.Add(new Column("zip", "char", 5, false, null));
-			t.Constraints.Add(new Constraint("PK_Address", "PRIMARY KEY", "id"));
+			t.AddConstraint(new Constraint("PK_Address", "PRIMARY KEY", "id"));
 
 			var getAddress = new Routine("dbo", "GetAddress", null);
 			getAddress.Text = @"

--- a/test/TableTester.cs
+++ b/test/TableTester.cs
@@ -34,8 +34,8 @@ namespace SchemaZen.test {
 			//test equal
 			t1.Columns.Add(new Column("first", "varchar", 30, false, null));
 			t2.Columns.Add(new Column("first", "varchar", 30, false, null));
-			t1.Constraints.Add(new Constraint("PK_Test", "PRIMARY KEY", "first"));
-			t2.Constraints.Add(new Constraint("PK_Test", "PRIMARY KEY", "first"));
+			t1.AddConstraint(new Constraint("PK_Test", "PRIMARY KEY", "first"));
+			t2.AddConstraint(new Constraint("PK_Test", "PRIMARY KEY", "first"));
 
 			diff = t1.Compare(t2);
 			Assert.IsNotNull(diff);
@@ -75,7 +75,7 @@ namespace SchemaZen.test {
 			t.Columns.Add(new Column("code", "char", 1, false, null));
 			t.Columns.Add(new Column("description", "varchar", 20, false, null));
 			t.Columns.Find("id").Identity = new Identity(1, 1);
-			t.Constraints.Add(new Constraint("PK_Status", "PRIMARY KEY", "id"));
+			t.AddConstraint(new Constraint("PK_Status", "PRIMARY KEY", "id"));
 
 			var conn = TestHelper.GetConnString("TESTDB");
 			DBHelper.DropDb(conn);
@@ -113,7 +113,7 @@ namespace SchemaZen.test {
 			computedCol.ComputedDefinition = "code + ' : ' + description";
 			t.Columns.Add(computedCol);
 			t.Columns.Find("id").Identity = new Identity(1, 1);
-			t.Constraints.Add(new Constraint("PK_Status", "PRIMARY KEY", "id"));
+			t.AddConstraint(new Constraint("PK_Status", "PRIMARY KEY", "id"));
 
 			var conn = TestHelper.GetConnString("TESTDB");
 			DBHelper.DropDb(conn);
@@ -151,7 +151,7 @@ namespace SchemaZen.test {
 			t.Columns.Add(new Column("code", "char", 1, false, null));
 			t.Columns.Add(new Column("description", "varchar", 20, false, null));
 			t.Columns.Find("id").Identity = new Identity(1, 1);
-			t.Constraints.Add(new Constraint("PK_Example", "PRIMARY KEY", "id"));
+			t.AddConstraint(new Constraint("PK_Example", "PRIMARY KEY", "id"));
 
 			var conn = TestHelper.GetConnString("TESTDB");
 			DBHelper.DropDb(conn);
@@ -186,8 +186,8 @@ namespace SchemaZen.test {
 		public void TestLargeAmountOfRowsImportAndExport() {
 			var t = new Table("dbo", "TestData");
 			t.Columns.Add(new Column("test_field", "int", false, null));
-			t.Constraints.Add(new Constraint("PK_TestData", "PRIMARY KEY", "test_field"));
-			t.Constraints.Add(new Constraint("IX_TestData_PK", "INDEX", "test_field") { Clustered = true, Table = t, Unique = true }); // clustered index is required to ensure the row order is the same as what we import
+			t.AddConstraint(new Constraint("PK_TestData", "PRIMARY KEY", "test_field"));
+			t.AddConstraint(new Constraint("IX_TestData_PK", "INDEX", "test_field") { Clustered = true, Table = t, Unique = true }); // clustered index is required to ensure the row order is the same as what we import
 
 			var conn = TestHelper.GetConnString("TESTDB");
 			DBHelper.DropDb(conn);


### PR DESCRIPTION
Hi Seth,

I have modified the `DatabaseTester.TestScriptToDir` test to include scripting a user defined table type to prove that it currently doesn't work properly - at the moment, the test fails. This relates to issue #57.

I have then made two fixes:
- one is to include the `table_types` directory in the `dirs` variable in the `Database` class, to ensure that it executes the scripts in this folder in create mode.
- the second is to only script a `Constraint`s name when the table it applies to is not a table type. As part of this fix, I changed the way constraints are added to a table, to ensure that the `Table` field is always set, previously it wasn't being set from the tests. Because table type constraints don't have names in the script, I also had to change the way constraints are compared for table types, to show that the related tables are successful.

All in all, these changes turn this failing test back to green.