### PR TITLE
Fix nvarchar(max) in table types, and escape user names

### DIFF
--- a/model/Database.cs
+++ b/model/Database.cs
@@ -612,7 +612,7 @@ order by fk.name, fkc.constraint_column_id
 					t.name as DATA_TYPE,
 					c.column_id as ORDINAL_POSITION,
 					CASE WHEN c.is_nullable = 1 THEN 'YES' ELSE 'NO' END as IS_NULLABLE,
-					CASE WHEN t.name = 'nvarchar' THEN CAST(c.max_length as int)/2 ELSE CAST(c.max_length as int) END as CHARACTER_MAXIMUM_LENGTH,
+					CASE WHEN t.name = 'nvarchar' and c.max_length > 0 THEN CAST(c.max_length as int)/2 ELSE CAST(c.max_length as int) END as CHARACTER_MAXIMUM_LENGTH,
 					c.precision as NUMERIC_PRECISION,
 					CAST(c.scale as int) as NUMERIC_SCALE,
 					CASE WHEN c.is_rowguidcol = 1 THEN 'YES' ELSE 'NO' END as IS_ROW_GUID_COL

--- a/model/SqlUser.cs
+++ b/model/SqlUser.cs
@@ -25,7 +25,7 @@ namespace SchemaZen.model {
 ", Name, "0x" + new SoapHexBinary(PasswordHash));
 
 			return login +
-			       string.Format("CREATE USER {0} {1} {2}{3}", Name, PasswordHash == null ? "WITHOUT LOGIN" : "FOR LOGIN " + Name,
+			       string.Format("CREATE USER [{0}] {1} {2}{3}", Name, PasswordHash == null ? "WITHOUT LOGIN" : "FOR LOGIN " + Name,
 				       string.IsNullOrEmpty(Owner) ? string.Empty : "WITH DEFAULT_SCHEMA = ", Owner)
 			       + "\r\n" +
 			       string.Join("\r\n",

--- a/test/DatabaseTester.cs
+++ b/test/DatabaseTester.cs
@@ -187,7 +187,8 @@ namespace SchemaZen.test {
 			var setupSQL1 = @"
 CREATE TYPE [dbo].[MyTableType] AS TABLE(
 	[ID] [nvarchar](250) NULL,
-	[Value] [numeric](5, 1) NULL
+	[Value] [numeric](5, 1) NULL,
+	[LongNVarchar] [nvarchar](max) NULL
 )
 
 ";
@@ -209,6 +210,7 @@ CREATE TYPE [dbo].[MyTableType] AS TABLE(
 			Assert.AreEqual(250, db.TableTypes[0].Columns.Items[0].Length);
 			Assert.AreEqual(1, db.TableTypes[0].Columns.Items[1].Scale);
 			Assert.AreEqual(5, db.TableTypes[0].Columns.Items[1].Precision);
+			Assert.AreEqual(-1, db.TableTypes[0].Columns.Items[2].Length); //nvarchar(max) is encoded as -1
 			Assert.AreEqual("MyTableType", db.TableTypes[0].Name);
 			Assert.IsTrue(File.Exists(db.Name + "\\table_types\\TYPE_MyTableType.sql"));
 

--- a/test/UserTester.cs
+++ b/test/UserTester.cs
@@ -1,0 +1,15 @@
+﻿using NUnit.Framework;
+using SchemaZen.model;
+
+namespace SchemaZen.test {
+    [TestFixture]
+    class UserTester {
+        [Test]
+        public void TestUserNameShouldBeEscaped() {
+            var user = new SqlUser("foo.bar", "dbo");
+            var createScript = user.ScriptCreate();
+
+            StringAssert.StartsWith("CREATE USER [foo.bar]", createScript);
+        }
+    }
+}

--- a/test/test.csproj
+++ b/test/test.csproj
@@ -75,6 +75,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="UserTester.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />


### PR DESCRIPTION
Sorry for combining two issues in one PR. They were both pretty small though.

- There was a bug where if a table type had a nvarchar(max) field in it, that field was being serialized out with a length of 0 instead of the correct -1. Fixed that.
- Usernames were not being escaped when written to SQL file, which means that a user with (for instance) a dot or a space in their name caused an error.