### PR TITLE
Add support for table indexes with filters

### DIFF
--- a/model/Column.cs
+++ b/model/Column.cs
@@ -88,6 +88,7 @@ namespace SchemaZen.model {
 					case "timestamp":
 					case "tinyint":
 					case "uniqueidentifier":
+					case "geography":
 					case "xml":
 
 						return string.Format("[{0}] [{1}] {2} {3} {4} {5}", Name, Type, IsNullableText,

--- a/model/Constraint.cs
+++ b/model/Constraint.cs
@@ -9,6 +9,7 @@ namespace SchemaZen.model {
 		public string Name { get; set; }
 		public Table Table;
 		public string Type;
+		public string Filter;
 		public bool Unique;
 		private bool IsNotForReplication;
 		private string CheckConstraintExpression;
@@ -49,6 +50,10 @@ namespace SchemaZen.model {
 					string.Join(", ", Columns.Select(c => c.Script()).ToArray()));
 				if (IncludedColumns.Count > 0) {
 					sql += string.Format(" INCLUDE ([{0}])", string.Join("], [", IncludedColumns.ToArray()));
+				}
+				if (!string.IsNullOrEmpty(Filter))
+				{
+				sql += string.Format(" WHERE {0}", Filter);
 				}
 				return sql;
 			}

--- a/model/Database.cs
+++ b/model/Database.cs
@@ -457,6 +457,7 @@ order by fk.name, fkc.constraint_column_id
 						i.is_unique_constraint,
 						i.is_unique, 
 						i.type_desc,
+						i.filter_definition,
 						isnull(ic.is_included_column, 0) as is_included_column,
                         ic.is_descending_key
 					from (
@@ -492,6 +493,8 @@ order by fk.name, fkc.constraint_column_id
 					}
 					c.Clustered = (string) dr["type_desc"] == "CLUSTERED";
 					c.Unique = (bool) dr["is_unique"];
+					var filter = dr["filter_definition"].ToString(); //can be null
+					c.Filter = filter;
 					if ((bool) dr["is_included_column"]) {
 						c.IncludedColumns.Add((string) dr["columnName"]);
 					} else {

--- a/test/DatabaseTester.cs
+++ b/test/DatabaseTester.cs
@@ -107,6 +107,24 @@ namespace SchemaZen.test {
 		}
 
 		[Test]
+		public void TestTableIndexesWithFilter() {
+			TestHelper.DropDb("TEST");
+			TestHelper.ExecSql("CREATE DATABASE TEST","");
+
+			TestHelper.ExecSql(@"CREATE TABLE MyTable (Id int, EndDate datetime)", "TEST");
+			TestHelper.ExecSql(@"CREATE NONCLUSTERED INDEX MyIndex ON MyTable (Id) WHERE (EndDate) IS NULL","TEST");
+
+			var db = new Database("TEST") {
+				Connection = TestHelper.GetConnString("TEST")
+			};
+			db.Load();
+			var result = db.ScriptCreate();
+			TestHelper.DropDb("TEST");
+
+			Assert.That(result, Is.StringContaining("CREATE  NONCLUSTERED INDEX [MyIndex] ON [dbo].[MyTable] ([Id]) WHERE ([EndDate] IS NULL)"));
+		}
+
+		[Test]
 		[Ignore("test won't work without license key for sqldbdiff")]
 		public void TestDiffScript() {
 			TestHelper.DropDb("TEST_SOURCE");


### PR DESCRIPTION
Currently table indexes are scripted out but their `where` clause is ignored.
This should fix it.

Also add support for geography type.