### PR TITLE
FKs ordering not consistent in script file

### DIFF
--- a/model/Database.cs
+++ b/model/Database.cs
@@ -1036,7 +1036,7 @@ where name = @dbname
 			WriteSchemaScript(log);
 			WriteScriptDir("tables", Tables.ToArray(), log);
 			WriteScriptDir("table_types", TableTypes.ToArray(), log);
-			WriteScriptDir("foreign_keys", ForeignKeys.ToArray(), log);
+			WriteScriptDir("foreign_keys", ForeignKeys.OrderBy(x => x.Name).ToArray(), log);
 			foreach (var routineType in Routines.GroupBy(x => x.RoutineType)) {
 				var dir = routineType.Key.ToString().ToLower() + "s";
 				WriteScriptDir(dir, routineType.ToArray(), log);


### PR DESCRIPTION
Hi

I am intending to use SchemaZen for source control. I have noticed that when adding a new foreign key to a table, it affects the order of the foreign key collection and causes a large number of other tables' FKs to be reordered in the script file, meaning that the diff is rather larger than the actual change.

To counter this I have ordered the FKs by name.

I have created a red test and a fix to bring back to green.

Dan 