### PR TITLE
Constraint ordering not consistent in script file

### DIFF
--- a/model/Table.cs
+++ b/model/Table.cs
@@ -138,7 +138,7 @@ end
 				IsType ? "AS TABLE " : string.Empty);
 			text.Append(Columns.Script());
 			if (_Constraints.Count > 0) text.AppendLine();
-			foreach (var c in _Constraints.Where(c => c.Type != "INDEX")) {
+			foreach (var c in _Constraints.OrderBy(x => x.Name).Where(c => c.Type != "INDEX")) {
 				text.AppendLine("   ," + c.ScriptCreate());
 			}
 			text.AppendLine(")");


### PR DESCRIPTION
Hi

As per my other PR (https://github.com/sethreno/schemazen/pull/88) I am intending to use SchemaZen for source control. I have noticed that constrains are randomly ordered in the script file for the table, causing tables' scripts to vary each run, meaning that the scripts are never consistent.

To counter this I have ordered the constraints by name. I have checked what Redgate do in their SQL compare product and they appear to order by name in this way.

I have created a red test and a fix to bring back to green.

Dan