### PR TITLE
Fk same name on up on del

### DIFF
--- a/model/Database.cs
+++ b/model/Database.cs
@@ -399,7 +399,7 @@ namespace SchemaZen.model {
 						DELETE_RULE,
 						fk.is_disabled
 					from INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS rc
-						inner join sys.foreign_keys fk on rc.CONSTRAINT_NAME = fk.name";
+						inner join sys.foreign_keys fk on rc.CONSTRAINT_NAME = fk.name and rc.CONSTRAINT_SCHEMA = OBJECT_SCHEMA_NAME(fk.parent_object_id)";
 			using (var dr = cm.ExecuteReader()) {
 				while (dr.Read()) {
 					var fk = FindForeignKey((string) dr["CONSTRAINT_NAME"], (string)dr["TABLE_SCHEMA"]);

--- a/test/DatabaseTester.cs
+++ b/test/DatabaseTester.cs
@@ -286,7 +286,7 @@ CREATE TABLE [dbo].[t1a]
 CREATE TABLE [dbo].[t1b]
 (
     a INT NOT NULL,
-    CONSTRAINT [FKName] FOREIGN KEY ([a]) REFERENCES [dbo].[t1a] ([a])
+    CONSTRAINT [FKName] FOREIGN KEY ([a]) REFERENCES [dbo].[t1a] ([a]) ON UPDATE CASCADE
 )
 
 CREATE TABLE [s2].[t2a]
@@ -298,7 +298,7 @@ CREATE TABLE [s2].[t2a]
 CREATE TABLE [s2].[t2b]
 (
     a INT NOT NULL,
-    CONSTRAINT [FKName] FOREIGN KEY ([a]) REFERENCES [s2].[t2a] ([a])
+    CONSTRAINT [FKName] FOREIGN KEY ([a]) REFERENCES [s2].[t2a] ([a]) ON DELETE CASCADE
 )
 
 ";
@@ -321,6 +321,11 @@ CREATE TABLE [s2].[t2b]
 			Assert.AreEqual(db.ForeignKeys[0].Name, db.ForeignKeys[1].Name);
 			Assert.AreNotEqual(db.ForeignKeys[0].Table.Owner, db.ForeignKeys[1].Table.Owner);
 
+            Assert.AreEqual("CASCADE", db.FindForeignKey("FKName", "dbo").OnUpdate);
+            Assert.AreEqual("NO ACTION", db.FindForeignKey("FKName", "s2").OnUpdate);
+
+            Assert.AreEqual("NO ACTION", db.FindForeignKey("FKName", "dbo").OnDelete);
+            Assert.AreEqual("CASCADE", db.FindForeignKey("FKName", "s2").OnDelete);
 		}
 
 		public void TestScriptViewInsteadOfTrigger() {


### PR DESCRIPTION
This is a fix for a nasty little bug with foreign keys with same name where CASCADE is picked up by non-cascading FKs if another FK with same name in different schema is CASCADE.

It is caused by the SQL for finding foreign keys not joining on table schema and so the cascade for a different FK is picked up.

I've got a red test and then a fix commit.


Dan