### PR TITLE
Trigger script without SETs produces invalid script

### DIFF
--- a/model/Models/Routine.cs
+++ b/model/Models/Routine.cs
@@ -67,7 +67,7 @@ namespace SchemaZen.Library.Models {
 
 			if (RoutineType == RoutineKind.Trigger)
 				after +=
-					string.Format("{0} TRIGGER [{1}].[{2}] ON [{3}].[{4}]", Disabled ? "DISABLE" : "ENABLE", Owner, Name,
+					Environment.NewLine + string.Format("{0} TRIGGER [{1}].[{2}] ON [{3}].[{4}]", Disabled ? "DISABLE" : "ENABLE", Owner, Name,
 						RelatedTableSchema, RelatedTableName) + Environment.NewLine + "GO" + Environment.NewLine;
 
 			if (string.IsNullOrEmpty(definition))


### PR DESCRIPTION
If your database settings for ANSI_NULLS and QUOTED_IDENTIFIER are ON, then the SETs are not outputted in the script.

This is fine, but if your trigger definition does not have a new line at the end, then the ENABLE ends up being added straight onto the end of the definition, giving you e.g. "INSERTEDENABLE"

I have added a newline before the ENABLE keyword to guarantee that this can never happen.

If you'd like me to do something different, let me know.

Thanks