### PR TITLE
New Features 

### DIFF
--- a/console/BaseCommand.cs
+++ b/console/BaseCommand.cs
@@ -23,7 +23,11 @@ namespace SchemaZen.console
                 "o|overwrite=",
                 "Overwrite existing target without prompt.",
                 o => Overwrite = o != null);
-            HasOption(
+			HasOption(
+				"m|merge=",
+				"Merge into existing target without prompt.",
+				m => Merge = m != null);
+			HasOption(
                 "v|verbose=",
                 "Enable verbose log messages.",
                 o => Verbose = o != null);
@@ -40,7 +44,8 @@ namespace SchemaZen.console
         protected string Pass { get; set; }
         protected string ScriptDir { get; set; }
         protected bool Overwrite { get; set; }
-        protected bool Verbose { get; set; }
+		protected bool Merge { get; set; }
+		protected bool Verbose { get; set; }
         protected string DatabaseFilesPath { get; set; }
     }
 }

--- a/console/BaseCommand.cs
+++ b/console/BaseCommand.cs
@@ -24,10 +24,6 @@ namespace SchemaZen.console
                 "Overwrite existing target without prompt.",
                 o => Overwrite = o != null);
 			HasOption(
-				"m|merge=",
-				"Merge into existing target without prompt.",
-				m => Merge = m != null);
-			HasOption(
                 "v|verbose=",
                 "Enable verbose log messages.",
                 o => Verbose = o != null);

--- a/console/Create.cs
+++ b/console/Create.cs
@@ -25,7 +25,8 @@ namespace SchemaZen.console {
                 Server = Server,
                 User = User,
                 Logger = _logger,
-                Overwrite = Overwrite
+                Overwrite = Overwrite,
+				Merge = Merge
             };
 
 		    try {

--- a/console/Create.cs
+++ b/console/Create.cs
@@ -18,7 +18,13 @@ namespace SchemaZen.console {
 				"m|merge=",
 				"Merge into existing target without prompt.",
 				m => Merge = m != null);
+			HasOption(
+				"i|ignoreDuplicateKeyErrors=",
+				"Ignores Duplicate Key errors when importing data.",
+				i => IgnoreDuplicateKeys = i != null);
 		}
+
+		public bool IgnoreDuplicateKeys { get; set; }
 
 		public override int Run(string[] remainingArguments) {
             _logger = new Logger(Verbose);
@@ -33,8 +39,9 @@ namespace SchemaZen.console {
                 User = User,
                 Logger = _logger,
                 Overwrite = Overwrite,
-				Merge = Merge
-            };
+				Merge = Merge,
+				IgnoreDuplicateKeys = IgnoreDuplicateKeys
+			};
 
 		    try {
 		        createCommand.Execute(DatabaseFilesPath);

--- a/console/Create.cs
+++ b/console/Create.cs
@@ -9,9 +9,16 @@ using SchemaZen.Library.Models;
 namespace SchemaZen.console {
 	public class Create : BaseCommand {
         private Logger _logger;
-        public Create()
+
+		public Create()
 			: base(
-				"Create", "Create the specified database from scripts.") { }
+				"Create", "Create the specified database from scripts.") {
+
+			HasOption(
+				"m|merge=",
+				"Merge into existing target without prompt.",
+				m => Merge = m != null);
+		}
 
 		public override int Run(string[] remainingArguments) {
             _logger = new Logger(Verbose);

--- a/console/Program.cs
+++ b/console/Program.cs
@@ -1,11 +1,26 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+using System.Text;
 using ManyConsole;
 
 namespace SchemaZen.console {
 	internal class Program {
 		private static int Main(string[] args) {
+			string loc = Assembly.GetEntryAssembly().Location;
+			string config = string.Concat(loc, ".config");
+			if (!File.Exists(config)) {
+				System.Text.StringBuilder sb = new StringBuilder();
+				sb.AppendLine("<?xml version=\"1.0\" encoding=\"utf-8\" ?>");
+				sb.AppendLine("<configuration>");
+				sb.AppendLine("<startup useLegacyV2RuntimeActivationPolicy=\"true\"/>");
+				sb.AppendLine("</configuration>");
+
+				
+				System.IO.File.WriteAllText(config, sb.ToString());
+			}
 			try {
 				return ConsoleCommandDispatcher.DispatchCommand(
 					GetCommands(), args, Console.Out);

--- a/console/Schemazen.Console.csproj
+++ b/console/Schemazen.Console.csproj
@@ -45,6 +45,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -53,6 +54,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="ManyConsole">
@@ -60,6 +62,10 @@
     </Reference>
     <Reference Include="NDesk.Options">
       <HintPath>..\packages\NDesk.Options.0.2.1\lib\NDesk.Options.dll</HintPath>
+    </Reference>
+    <Reference Include="nunit.framework, Version=3.6.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.6.0\lib\net35\nunit.framework.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">
@@ -130,8 +136,7 @@
   </Target>
   -->
   <PropertyGroup>
-    <PostBuildEvent>"$(SolutionDir)\packages\ILMerge.2.14.1208\tools\ilmerge.exe" /target:exe /out:SchemaZen.exe console.exe SchemaZen.Library.dll ManyConsole.dll NDesk.Options.dll
-</PostBuildEvent>
+    <PostBuildEvent>"$(SolutionDir)\packages\ILMerge.2.14.1208\tools\ilmerge.exe" /target:exe /out:SchemaZen.exe console.exe SchemaZen.Library.dll ManyConsole.dll NDesk.Options.dll</PostBuildEvent>
   </PropertyGroup>
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
 </Project>

--- a/console/Script.cs
+++ b/console/Script.cs
@@ -36,6 +36,10 @@ namespace SchemaZen.console
 			   "filterProps=",
 			   "A comma separated list of the database properties that will not be scripted.",
 			   o => FilterProps = o);
+			HasOption(
+				"collateColumns=",
+				"Keep individual column collation with COLLATE keyword.",
+				c => CollateColumns = c != null);
 		}
 
         private Logger _logger;
@@ -44,8 +48,9 @@ namespace SchemaZen.console
 		protected string FilterProps { get; set; }
 		protected string DataTablesPattern { get; set; }
         protected string TableHint { get; set; }
+		protected bool CollateColumns { get; set; }
 
-        public override int Run(string[] args) {
+		public override int Run(string[] args) {
             _logger = new Logger(Verbose);
 
             if (!Overwrite && Directory.Exists(ScriptDir))
@@ -70,7 +75,7 @@ namespace SchemaZen.console
 			var namesAndSchemas = HandleDataTables(DataTables);
 
             try { 
-                scriptCommand.Execute(namesAndSchemas, DataTablesPattern, TableHint, filteredTypes, filteredProps);
+                scriptCommand.Execute(namesAndSchemas, DataTablesPattern, TableHint, filteredTypes, filteredProps, CollateColumns);
             } catch (Exception ex) {
 		        throw new ConsoleHelpAsException(ex.Message);
             }

--- a/console/Script.cs
+++ b/console/Script.cs
@@ -32,12 +32,17 @@ namespace SchemaZen.console
                 "filterTypes=",
                 "A comma separated list of the types that will not be scripted. Valid types: " + Database.ValidTypes,
                 o => FilterTypes = o);
-        }
+			HasOption(
+			   "filterProps=",
+			   "A comma separated list of the database properties that will not be scripted.",
+			   o => FilterProps = o);
+		}
 
         private Logger _logger;
         protected string DataTables { get; set; }
         protected string FilterTypes { get; set; }
-        protected string DataTablesPattern { get; set; }
+		protected string FilterProps { get; set; }
+		protected string DataTablesPattern { get; set; }
         protected string TableHint { get; set; }
 
         public override int Run(string[] args) {
@@ -61,10 +66,11 @@ namespace SchemaZen.console
             };
 
             var filteredTypes = HandleFilteredTypes();
-            var namesAndSchemas = HandleDataTables(DataTables);
+			var filteredProps = FilterProps?.Split(',').ToList() ?? new List<string>();
+			var namesAndSchemas = HandleDataTables(DataTables);
 
             try { 
-                scriptCommand.Execute(namesAndSchemas, DataTablesPattern, TableHint, filteredTypes);
+                scriptCommand.Execute(namesAndSchemas, DataTablesPattern, TableHint, filteredTypes, filteredProps);
             } catch (Exception ex) {
 		        throw new ConsoleHelpAsException(ex.Message);
             }

--- a/console/Script.cs
+++ b/console/Script.cs
@@ -40,6 +40,10 @@ namespace SchemaZen.console
 				"collateColumns=",
 				"Keep individual column collation with COLLATE keyword.",
 				c => CollateColumns = c != null);
+			HasOption(
+				"fileGroup=",
+				"Name of a specific filegroup/file to script database to.",
+				f => FileGroup = f);
 		}
 
         private Logger _logger;
@@ -49,6 +53,7 @@ namespace SchemaZen.console
 		protected string DataTablesPattern { get; set; }
         protected string TableHint { get; set; }
 		protected bool CollateColumns { get; set; }
+		protected string FileGroup { get; set; }
 
 		public override int Run(string[] args) {
             _logger = new Logger(Verbose);
@@ -75,7 +80,7 @@ namespace SchemaZen.console
 			var namesAndSchemas = HandleDataTables(DataTables);
 
             try { 
-                scriptCommand.Execute(namesAndSchemas, DataTablesPattern, TableHint, filteredTypes, filteredProps, CollateColumns);
+                scriptCommand.Execute(namesAndSchemas, DataTablesPattern, TableHint, filteredTypes, filteredProps, CollateColumns, FileGroup);
             } catch (Exception ex) {
 		        throw new ConsoleHelpAsException(ex.Message);
             }

--- a/console/app.config
+++ b/console/app.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-	<startup useLegacyV2RuntimeActivationPolicy="true"/>
+	<startup useLegacyV2RuntimeActivationPolicy="true"><supportedRuntime version="v2.0.50727"/></startup>
 </configuration>

--- a/console/app.config
+++ b/console/app.config
@@ -1,7 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
-  <startup>
-    <supportedRuntime version="v2.0.50727" />
-  </startup>
+	<startup useLegacyV2RuntimeActivationPolicy="true"/>
 </configuration>

--- a/console/packages.config
+++ b/console/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-
 <packages>
   <package id="ILMerge" version="2.14.1208" targetFramework="net35" />
   <package id="ManyConsole" version="0.4.2.16" targetFramework="net35" />
   <package id="NDesk.Options" version="0.2.1" targetFramework="net35" />
+  <package id="NUnit" version="3.6.0" targetFramework="net35" />
 </packages>

--- a/model/Command/BaseCommand.cs
+++ b/model/Command/BaseCommand.cs
@@ -15,7 +15,7 @@ namespace SchemaZen.Library.Command {
         public bool Overwrite { get; set; }
 		public bool Merge { get; set; }
 
-		public Database CreateDatabase(IList<string> filteredTypes = null, IList<string> filteredProps = null, bool collateColumns = false)
+		public Database CreateDatabase(IList<string> filteredTypes = null, IList<string> filteredProps = null, bool collateColumns = false, string fileGroup = null)
         {
             filteredTypes = filteredTypes ?? new List<string>();
 
@@ -34,7 +34,8 @@ namespace SchemaZen.Library.Command {
                 {
                     Connection = ConnectionString,
                     Dir = ScriptDir,
-					CollateColumns = collateColumns
+					CollateColumns = collateColumns,
+					FileGroup = fileGroup
 				};
             }
             if (string.IsNullOrEmpty(Server) || string.IsNullOrEmpty(DbName))
@@ -60,7 +61,8 @@ namespace SchemaZen.Library.Command {
 			{
                 Connection = builder.ToString(),
                 Dir = ScriptDir,
-				CollateColumns = collateColumns
+				CollateColumns = collateColumns,
+				FileGroup = fileGroup
 			};
         }
 

--- a/model/Command/BaseCommand.cs
+++ b/model/Command/BaseCommand.cs
@@ -14,6 +14,7 @@ namespace SchemaZen.Library.Command {
         public ILogger Logger { get; set; }
         public bool Overwrite { get; set; }
 		public bool Merge { get; set; }
+		public bool IgnoreDuplicateKeys { get; set; }
 
 		public Database CreateDatabase(IList<string> filteredTypes = null, IList<string> filteredProps = null, bool collateColumns = false, string fileGroup = null)
         {

--- a/model/Command/BaseCommand.cs
+++ b/model/Command/BaseCommand.cs
@@ -15,7 +15,7 @@ namespace SchemaZen.Library.Command {
         public bool Overwrite { get; set; }
 		public bool Merge { get; set; }
 
-		public Database CreateDatabase(IList<string> filteredTypes = null, IList<string> filteredProps = null)
+		public Database CreateDatabase(IList<string> filteredTypes = null, IList<string> filteredProps = null, bool collateColumns = false)
         {
             filteredTypes = filteredTypes ?? new List<string>();
 
@@ -33,8 +33,9 @@ namespace SchemaZen.Library.Command {
                 return new Database(filteredTypes, filteredProps)
                 {
                     Connection = ConnectionString,
-                    Dir = ScriptDir
-                };
+                    Dir = ScriptDir,
+					CollateColumns = collateColumns
+				};
             }
             if (string.IsNullOrEmpty(Server) || string.IsNullOrEmpty(DbName))
             {
@@ -58,8 +59,9 @@ namespace SchemaZen.Library.Command {
             return new Database(filteredTypes, filteredProps)
 			{
                 Connection = builder.ToString(),
-                Dir = ScriptDir
-            };
+                Dir = ScriptDir,
+				CollateColumns = collateColumns
+			};
         }
 
         public void AddDataTable(Database db, string name, string schema)

--- a/model/Command/BaseCommand.cs
+++ b/model/Command/BaseCommand.cs
@@ -13,12 +13,15 @@ namespace SchemaZen.Library.Command {
         public string ScriptDir { get; set; }
         public ILogger Logger { get; set; }
         public bool Overwrite { get; set; }
+		public bool Merge { get; set; }
 
-        public Database CreateDatabase(IList<string> filteredTypes = null)
+		public Database CreateDatabase(IList<string> filteredTypes = null, IList<string> filteredProps = null)
         {
             filteredTypes = filteredTypes ?? new List<string>();
 
-            if (!string.IsNullOrEmpty(ConnectionString))
+			filteredProps = filteredProps ?? new List<string>();
+
+			if (!string.IsNullOrEmpty(ConnectionString))
             {
                 if (!string.IsNullOrEmpty(Server) ||
                     !string.IsNullOrEmpty(DbName) ||
@@ -27,7 +30,7 @@ namespace SchemaZen.Library.Command {
                 {
                     throw new ArgumentException("You must not provide both a connection string and a server/db/user/password");
                 }
-                return new Database(filteredTypes)
+                return new Database(filteredTypes, filteredProps)
                 {
                     Connection = ConnectionString,
                     Dir = ScriptDir
@@ -52,8 +55,8 @@ namespace SchemaZen.Library.Command {
                 builder.UserID = User;
                 builder.Password = Pass;
             }
-            return new Database(filteredTypes)
-            {
+            return new Database(filteredTypes, filteredProps)
+			{
                 Connection = builder.ToString(),
                 Dir = ScriptDir
             };

--- a/model/Command/CreateCommand.cs
+++ b/model/Command/CreateCommand.cs
@@ -13,14 +13,14 @@ namespace SchemaZen.Library.Command {
                 throw new FileNotFoundException(string.Format("Snapshot dir {0} does not exist.", db.Dir));
             }
 
-            if (!Overwrite && (DBHelper.DbExists(db.Connection)))
+            if (!Overwrite && !Merge && (DBHelper.DbExists(db.Connection)))
             {
-                var msg = string.Format("{0} {1} already exists - use overwrite property if you want to drop it",
+                var msg = string.Format("{0} {1} already exists - use 'overwrite' property if you want to drop it or 'merge' property to merge the schema into an it.",
     Server, DbName);
                 throw new InvalidOperationException(msg);
             }
 
-            db.CreateFromDir(Overwrite, databaseFilesPath, Logger.Log);
+            db.CreateFromDir(Overwrite, Merge, databaseFilesPath, Logger.Log);
             Logger.Log(TraceLevel.Info, Environment.NewLine + "Database created successfully.");
         }
     }

--- a/model/Command/CreateCommand.cs
+++ b/model/Command/CreateCommand.cs
@@ -8,6 +8,7 @@ namespace SchemaZen.Library.Command {
         public void Execute(string databaseFilesPath)
         {
             var db = CreateDatabase();
+	        db.IgnoreDuplicateKeys = IgnoreDuplicateKeys;
             if (!Directory.Exists(db.Dir))
             {
                 throw new FileNotFoundException(string.Format("Snapshot dir {0} does not exist.", db.Dir));

--- a/model/Command/ScriptCommand.cs
+++ b/model/Command/ScriptCommand.cs
@@ -8,14 +8,14 @@ namespace SchemaZen.Library.Command {
     public class ScriptCommand : BaseCommand {
 
         public void Execute(Dictionary<string, string> namesAndSchemas, string dataTablesPattern, 
-            string tableHint, List<string> filteredTypes)
+            string tableHint, List<string> filteredTypes, List<string> filteredProps)
         {
             if (!Overwrite && Directory.Exists(ScriptDir)) {
                 var message = string.Format("{0} already exists - you must set overwrite to true", ScriptDir);
                 throw new InvalidOperationException(message);
             }
 
-            var db = CreateDatabase(filteredTypes);
+            var db = CreateDatabase(filteredTypes, filteredProps);
 
             Logger.Log(TraceLevel.Verbose, "Loading database schema...");
             db.Load();

--- a/model/Command/ScriptCommand.cs
+++ b/model/Command/ScriptCommand.cs
@@ -8,14 +8,14 @@ namespace SchemaZen.Library.Command {
     public class ScriptCommand : BaseCommand {
 
         public void Execute(Dictionary<string, string> namesAndSchemas, string dataTablesPattern, 
-            string tableHint, List<string> filteredTypes, List<string> filteredProps, bool collateColumns = false)
+            string tableHint, List<string> filteredTypes, List<string> filteredProps, bool collateColumns = false, string fileGroup = null)
         {
             if (!Overwrite && Directory.Exists(ScriptDir)) {
                 var message = string.Format("{0} already exists - you must set overwrite to true", ScriptDir);
                 throw new InvalidOperationException(message);
             }
 
-            var db = CreateDatabase(filteredTypes, filteredProps, collateColumns);
+            var db = CreateDatabase(filteredTypes, filteredProps, collateColumns, fileGroup);
 
             Logger.Log(TraceLevel.Verbose, "Loading database schema...");
             db.Load();

--- a/model/Command/ScriptCommand.cs
+++ b/model/Command/ScriptCommand.cs
@@ -8,14 +8,14 @@ namespace SchemaZen.Library.Command {
     public class ScriptCommand : BaseCommand {
 
         public void Execute(Dictionary<string, string> namesAndSchemas, string dataTablesPattern, 
-            string tableHint, List<string> filteredTypes, List<string> filteredProps)
+            string tableHint, List<string> filteredTypes, List<string> filteredProps, bool collateColumns = false)
         {
             if (!Overwrite && Directory.Exists(ScriptDir)) {
                 var message = string.Format("{0} already exists - you must set overwrite to true", ScriptDir);
                 throw new InvalidOperationException(message);
             }
 
-            var db = CreateDatabase(filteredTypes, filteredProps);
+            var db = CreateDatabase(filteredTypes, filteredProps, collateColumns);
 
             Logger.Log(TraceLevel.Verbose, "Loading database schema...");
             db.Load();

--- a/model/Models/Column.cs
+++ b/model/Models/Column.cs
@@ -8,7 +8,8 @@ namespace SchemaZen.Library.Models {
 		public int Length;
 		public string Name;
 		public string Collation;
-		private string Collate => Collation == null ? "" : $"COLLATE {Collation}";
+		public bool CollateColumns { get; set; }
+		private string Collate => CollateColumns && Collation == null ? "" : $"COLLATE {Collation}";
 		public int Position;
 		public byte Precision;
 		public int Scale;

--- a/model/Models/Column.cs
+++ b/model/Models/Column.cs
@@ -9,7 +9,7 @@ namespace SchemaZen.Library.Models {
 		public string Name;
 		public string Collation;
 		public bool CollateColumns { get; set; }
-		private string Collate => CollateColumns && Collation == null ? "" : $"COLLATE {Collation}";
+		private string Collate => !CollateColumns || Collation == null ? "" : $"COLLATE {Collation}";
 		public int Position;
 		public byte Precision;
 		public int Scale;

--- a/model/Models/Column.cs
+++ b/model/Models/Column.cs
@@ -7,6 +7,8 @@ namespace SchemaZen.Library.Models {
 		public bool IsNullable;
 		public int Length;
 		public string Name;
+		public string Collation;
+		private string Collate => Collation == null ? "" : $"COLLATE {Collation}";
 		public int Position;
 		public byte Precision;
 		public int Scale;
@@ -91,8 +93,8 @@ namespace SchemaZen.Library.Models {
 					case "geography":
 					case "xml":
                     case "sysname":
-						return string.Format("[{0}] [{1}] {2} {3} {4} {5}", Name, Type, IsNullableText,
-							includeDefaultConstraint ? DefaultText : string.Empty, IdentityText, RowGuidColText);
+						return string.Format("[{0}] [{1}] {6} {2} {3} {4} {5}", Name, Type, IsNullableText,
+							includeDefaultConstraint ? DefaultText : string.Empty, IdentityText, RowGuidColText, Collate);
 					case "binary":
 					case "char":
 					case "nchar":
@@ -102,13 +104,13 @@ namespace SchemaZen.Library.Models {
 						var lengthString = Length.ToString();
 						if (lengthString == "-1") lengthString = "max";
 
-						return string.Format("[{0}] [{1}]({2}) {3} {4}", Name, Type, lengthString, IsNullableText,
-							includeDefaultConstraint ? DefaultText : string.Empty);
+						return string.Format("[{0}] [{1}]({2}) {5} {3} {4}", Name, Type, lengthString, IsNullableText,
+							includeDefaultConstraint ? DefaultText : string.Empty, Collate);
 					case "decimal":
 					case "numeric":
 
-						return string.Format("[{0}] [{1}]({2},{3}) {4} {5} {6}", Name, Type, Precision, Scale, IsNullableText,
-							includeDefaultConstraint ? DefaultText : string.Empty, IdentityText);
+						return string.Format("[{0}] [{1}]({2},{3}) {7} {4} {5} {6}", Name, Type, Precision, Scale, IsNullableText,
+							includeDefaultConstraint ? DefaultText : string.Empty, IdentityText, Collate);
 					default:
 						throw new NotSupportedException("Error scripting column " + Name + ". SQL data type " + Type + " is not supported.");
 				}

--- a/model/Models/Database.cs
+++ b/model/Models/Database.cs
@@ -1350,7 +1350,7 @@ where name = @dbname
 				var text = new StringBuilder();
 				text.AppendLine($@"
 DECLARE @FULL_PATH nvarchar(max) = (SELECT physical_name FROM sys.master_files WHERE name = 'master')
-DECLARE @PATH nvarchar(max) = (SELECT LEFT(@FULL_PATH,LEN(@FULL_PATH) - charindex('\\',reverse(@FULL_PATH),1) + 1))
+DECLARE @PATH nvarchar(max) = (SELECT LEFT(@FULL_PATH,LEN(@FULL_PATH) - charindex('\',reverse(@FULL_PATH),1) + 1))
 DECLARE @DB NVARCHAR(255) = DB_NAME()
 DECLARE @FILEGROUP_NAME NVARCHAR(255) = '{FileGroup}'
 Declare @Sql nvarchar(max) = '

--- a/model/Models/Database.cs
+++ b/model/Models/Database.cs
@@ -159,6 +159,7 @@ namespace SchemaZen.Library.Models {
 
 		public bool CollateColumns { get; set; }
 		public string FileGroup { get; internal set; }
+		public bool IgnoreDuplicateKeys { get; internal set; }
 
 		private void SetPropOnOff(string propName, object dbVal) {
 			if (dbVal != DBNull.Value) {
@@ -987,7 +988,7 @@ order by fk.name, fkc.constraint_column_id
 
 	    private void LoadTablesBase(SqlDataReader dr, bool areTableTypes, List<Table> tables) {
 			while (dr.Read()) {
-				tables.Add(new Table((string) dr["TABLE_SCHEMA"], (string) dr["TABLE_NAME"]) {IsType = areTableTypes, FileGroup = FileGroup});
+				tables.Add(new Table((string) dr["TABLE_SCHEMA"], (string) dr["TABLE_NAME"]) {IsType = areTableTypes, FileGroup = FileGroup, Database = this});
 			}
 		}
 

--- a/model/Models/Database.cs
+++ b/model/Models/Database.cs
@@ -157,7 +157,9 @@ namespace SchemaZen.Library.Models {
             get { return Dirs.Aggregate((x, y) => x + ", " + y); }
         }
 
-        private void SetPropOnOff(string propName, object dbVal) {
+		public bool CollateColumns { get; set; }
+
+		private void SetPropOnOff(string propName, object dbVal) {
 			if (dbVal != DBNull.Value) {
 				FindProp(propName).Value = (bool) dbVal ? "ON" : "OFF";
 			}
@@ -873,7 +875,7 @@ order by fk.name, fkc.constraint_column_id
 			}
 		}
 
-		private static void LoadColumnsBase(IDataReader dr, List<Table> tables) {
+		private void LoadColumnsBase(IDataReader dr, List<Table> tables) {
 			Table table = null;
 
 			while (dr.Read()) {
@@ -883,7 +885,8 @@ order by fk.name, fkc.constraint_column_id
 					Type = (string) dr["DATA_TYPE"],
 					IsNullable = (string) dr["IS_NULLABLE"] == "YES",
 					Position = (int) dr["ORDINAL_POSITION"],
-					IsRowGuidCol = (string) dr["IS_ROW_GUID_COL"] == "YES"
+					IsRowGuidCol = (string) dr["IS_ROW_GUID_COL"] == "YES",
+					CollateColumns = CollateColumns
 				};
 
 				switch (c.Type) {

--- a/model/Models/Database.cs
+++ b/model/Models/Database.cs
@@ -985,9 +985,9 @@ order by fk.name, fkc.constraint_column_id
 
 	    }
 
-	    private static void LoadTablesBase(SqlDataReader dr, bool areTableTypes, List<Table> tables) {
+	    private void LoadTablesBase(SqlDataReader dr, bool areTableTypes, List<Table> tables) {
 			while (dr.Read()) {
-				tables.Add(new Table((string) dr["TABLE_SCHEMA"], (string) dr["TABLE_NAME"]) {IsType = areTableTypes});
+				tables.Add(new Table((string) dr["TABLE_SCHEMA"], (string) dr["TABLE_NAME"]) {IsType = areTableTypes, FileGroup = FileGroup});
 			}
 		}
 

--- a/model/Models/FullTextCatalog.cs
+++ b/model/Models/FullTextCatalog.cs
@@ -9,12 +9,13 @@ namespace SchemaZen.Library.Models
 	{
 		public string Name { get; set; }
 		public string SchemaName { get; set; }
+		public string FileGroup { get; set; }
 		public bool AccentSensitivityOn { get; set; }
 
 
 		public string ScriptCreate() {
 			return $@"CREATE FULLTEXT CATALOG [{Name}]
-					ON FILEGROUP[PRIMARY]
+					ON FILEGROUP[{FileGroup}]
 					WITH ACCENT_SENSITIVITY = {(AccentSensitivityOn ? "ON" : "OFF")}
 					AUTHORIZATION[{SchemaName}]";
 		}

--- a/model/Models/FullTextCatalog.cs
+++ b/model/Models/FullTextCatalog.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace SchemaZen.Library.Models
+{
+	public class FullTextCatalog : INameable, IScriptable
+	{
+		public string Name { get; set; }
+		public string SchemaName { get; set; }
+		public bool AccentSensitivityOn { get; set; }
+
+
+		public string ScriptCreate() {
+			return $@"CREATE FULLTEXT CATALOG [{Name}]
+					ON FILEGROUP[PRIMARY]
+					WITH ACCENT_SENSITIVITY = {(AccentSensitivityOn ? "ON" : "OFF")}
+					AUTHORIZATION[{SchemaName}]";
+		}
+	}
+}

--- a/model/Models/FullTextIndex.cs
+++ b/model/Models/FullTextIndex.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace SchemaZen.Library.Models
+{
+	public class FullTextIndex : INameable, IScriptable
+	{
+		public string Name { get; set; }
+		public Dictionary<string, string> Columns = new Dictionary<string, string>();
+		public string Catalog { get; set; }
+		public string SchemaName { get; set; }
+		public bool Enabled { get; set; }
+		public Table Table { get; set; }
+
+		public string ScriptCreate() {
+			StringBuilder sb = new StringBuilder(300);
+			sb.Append(
+				$@"
+					CREATE FULLTEXT INDEX ON [{SchemaName}].[{Table.Name}] KEY INDEX [{Name}] ON [{Catalog}]
+				");
+			sb.Append("GO");
+			foreach (string key in Columns.Keys) {
+				sb.Append(
+				$@"
+					ALTER FULLTEXT INDEX ON [{SchemaName}].[{Table.Name}] ADD ({key} LANGUAGE {Columns[key]})
+				");
+				sb.Append("GO");
+			}
+			sb.Append(
+				$@"
+					ALTER FULLTEXT INDEX ON [{SchemaName}].[{Table.Name}] {(Enabled ? "ENABLE" : "DISABLE" )}
+				");
+			sb.Append("GO");
+			return sb.ToString();
+		}
+	}
+}

--- a/model/Models/Table.cs
+++ b/model/Models/Table.cs
@@ -153,11 +153,7 @@ end
 				text.AppendLine("   ," + c.ScriptCreate());
 			}
 
-			text.AppendLine(")");
-			if (!string.IsNullOrEmpty(FileGroup))
-			{
-				text.Append($" ON {FileGroup}");
-			}
+			text.AppendLine(")" + (string.IsNullOrEmpty(FileGroup) ? "" : $" ON {FileGroup}"));
 			text.AppendLine();
 			foreach (var c in _Constraints.Where(c => c.Type == "INDEX")) {
 				text.AppendLine(c.ScriptCreate());

--- a/model/Models/Table.cs
+++ b/model/Models/Table.cs
@@ -85,7 +85,7 @@ end
 				var c2 = t.Columns.Find(c.Name);
 				if (c2 == null) {
 					diff.ColumnsAdded.Add(c);
-				} else {
+				}				else {
 					//compare mutual columns
 					var cDiff = c.Compare(c2);
 					if (cDiff.IsDiff) {
@@ -105,17 +105,18 @@ end
 					var c2 = t.FindConstraint(c.Name);
 					if (c2 == null) {
 						diff.ConstraintsAdded.Add(c);
-					} else {
+					}					else {
 						if (c.ScriptCreate() != c2.ScriptCreate()) {
 							diff.ConstraintsChanged.Add(c);
 						}
 					}
 				}
+
 				//get deleted constraints
-				foreach (var c in t.Constraints.Where(c => FindConstraint(c.Name) == null)){
+				foreach (var c in t.Constraints.Where(c => FindConstraint(c.Name) == null)) {
 					diff.ConstraintsDeleted.Add(c);
 				}
-			} else {
+			}			else {
 				// compare constraints on table types, which can't be named in the script, but have names in the DB
 				var dest = Constraints.ToList();
 				var src = t.Constraints.ToList();
@@ -123,15 +124,16 @@ end
 				var j = from c1 in dest
 						join c2 in src on c1.ScriptCreate() equals c2.ScriptCreate() into match //new { c1.Type, c1.Unique, c1.Clustered, Columns = string.Join(",", c1.Columns.ToArray()), IncludedColumns = string.Join(",", c1.IncludedColumns.ToArray()) } equals new { c2.Type, c2.Unique, c2.Clustered, Columns = string.Join(",", c2.Columns.ToArray()), IncludedColumns = string.Join(",", c2.IncludedColumns.ToArray()) } into match
 						from m in match.DefaultIfEmpty()
-						select new { c1, m };
+				select new { c1, m };
 
 				foreach (var c in j) {
 					if (c.m == null) {
 						diff.ConstraintsAdded.Add(c.c1);
-					} else {
+					}					else {
 						src.Remove(c.m);
 					}
 				}
+
 				foreach (var c in src) {
 					diff.ConstraintsDeleted.Add(c);
 				}
@@ -149,23 +151,25 @@ end
 			foreach (var c in _Constraints.OrderBy(x => x.Name).Where(c => c.Type != "INDEX")) {
 				text.AppendLine("   ," + c.ScriptCreate());
 			}
+
 			text.AppendLine(")");
 			text.AppendLine();
 			foreach (var c in _Constraints.Where(c => c.Type == "INDEX")) {
 				text.AppendLine(c.ScriptCreate());
 			}
+
 			text.AppendLine();
 			foreach (var c in FullTextIndexes)
 			{
 				text.AppendLine(c.ScriptCreate());
 			}
+
 			return text.ToString();
 		}
 
 		public string ScriptDrop() {
 			return string.Format("DROP {2} [{0}].[{1}]", Owner, Name, IsType ? "TYPE" : "TABLE");
 		}
-
 
 		public void ExportData(string conn, TextWriter data, string tableHint = null) {
 			if (IsType)
@@ -177,6 +181,7 @@ end
 			foreach (var c in cols) {
 				sql.AppendFormat("[{0}],", c.Name);
 			}
+
 			sql.Remove(sql.Length - 1, 1);
 			sql.AppendFormat(" from [{0}].[{1}]", Owner, Name);
 			if (!string.IsNullOrEmpty(tableHint))
@@ -201,6 +206,7 @@ end
 								if (c != cols.Last())
 									data.Write(fieldSeparator);
 							}
+
 							data.WriteLine();
 						}
 					}
@@ -246,6 +252,7 @@ end
 								break;
 							}
 						}
+
 						linenumber++;
 
 						// Skip empty lines
@@ -259,15 +266,18 @@ end
 						if (fields.Length != dt.Columns.Count) {
 							throw new DataFileException("Incorrect number of columns", filename, linenumber);
 						}
+
 						for (var j = 0; j < fields.Length; j++) {
 							try {
 								row[j] = ConvertType(cols[j].Type,
 									fields[j].Replace(escapeRowSeparator, rowSeparator)
 									.Replace(escapeFieldSeparator, fieldSeparator));
-							} catch (FormatException ex) {
+							}
+							catch (FormatException ex) {
 								throw new DataFileException(string.Format("{0} at column {1}", ex.Message, j + 1), filename, linenumber);
 							}
 						}
+
 						dt.Rows.Add(row);
 
 						if (batch_rows == rowsInBatch) {
@@ -289,10 +299,11 @@ end
 
 			switch (sqlType.ToLower()) {
 				case "bit":
-					//added for compatibility with bcp
+				//added for compatibility with bcp
 					if (val == "0") val = "False";
-					if (val == "1") val = "True";
-					return bool.Parse(val);
+				if (val == "1") val = "True";
+				return bool.Parse(val);
+				case "date":
 				case "datetime":
 				case "datetime2":
 				case "smalldatetime":
@@ -345,10 +356,12 @@ end
 					if (c.Source.Default != null) {
 						text.AppendFormat("ALTER TABLE [{0}].[{1}] {2}\r\n", Owner, Name, c.Source.Default.ScriptDrop());
 					}
+
 					if (c.Target.Default != null) {
 						text.AppendFormat("ALTER TABLE [{0}].[{1}] {2}\r\n", Owner, Name, c.Target.Default.ScriptCreate(c.Target));
 					}
 				}
+
 				if (!c.OnlyDefaultIsDiff) {
 					text.AppendFormat("ALTER TABLE [{0}].[{1}] ALTER COLUMN {2}\r\n", Owner, Name, c.Target.ScriptAlter());
 				}

--- a/model/Models/Table.cs
+++ b/model/Models/Table.cs
@@ -196,10 +196,10 @@ end
 							foreach (var c in cols) {
 								if (dr[c.Name] is DBNull)
 									data.Write(nullValue);
-								if (c.Type.Contains("date") && c.Type != "datetimeoffset" && dr[c.Name] is DateTime)
-									data.Write(((DateTime)dr[c.Name]).Ticks);
 								else if (dr[c.Name] is byte[])
 									data.Write(new SoapHexBinary((byte[]) dr[c.Name]).ToString());
+								else if (c.Type.StartsWith("date", StringComparison.OrdinalIgnoreCase) && c.Type != "datetimeoffset" && dr[c.Name] is DateTime)
+									data.Write(((DateTime)dr[c.Name]).Ticks);
 								else
 									data.Write(dr[c.Name].ToString()
 										.Replace(fieldSeparator, escapeFieldSeparator)

--- a/model/Models/Table.cs
+++ b/model/Models/Table.cs
@@ -41,6 +41,7 @@ end
 		private List<FullTextIndex> FullTextIndexes = new List<FullTextIndex>();
 		public string Name { get; set; }
 		public string Owner { get; set; }
+		public string FileGroup { get; set; }
 		public bool IsType;
 
 		public Table(string owner, string name) {
@@ -153,6 +154,10 @@ end
 			}
 
 			text.AppendLine(")");
+			if (!string.IsNullOrEmpty(FileGroup))
+			{
+				text.Append($" ON {FileGroup}");
+			}
 			text.AppendLine();
 			foreach (var c in _Constraints.Where(c => c.Type == "INDEX")) {
 				text.AppendLine(c.ScriptCreate());

--- a/model/Models/Table.cs
+++ b/model/Models/Table.cs
@@ -195,7 +195,7 @@ end
 							foreach (var c in cols) {
 								if (dr[c.Name] is DBNull)
 									data.Write(nullValue);
-								if (c.Type.Contains("date") && c.Type != "datetimeoffset")
+								if (c.Type.Contains("date") && c.Type != "datetimeoffset" && dr[c.Name] is DateTime)
 									data.Write(((DateTime)dr[c.Name]).Ticks);
 								else if (dr[c.Name] is byte[])
 									data.Write(new SoapHexBinary((byte[]) dr[c.Name]).ToString());

--- a/model/Models/Table.cs
+++ b/model/Models/Table.cs
@@ -195,7 +195,7 @@ end
 							foreach (var c in cols) {
 								if (dr[c.Name] is DBNull)
 									data.Write(nullValue);
-								if (dr[c.Name] is DateTime)
+								if (c.Type.Contains("date") && c.Type != "datetimeoffset")
 									data.Write(((DateTime)dr[c.Name]).Ticks);
 								else if (dr[c.Name] is byte[])
 									data.Write(new SoapHexBinary((byte[]) dr[c.Name]).ToString());

--- a/model/Schemazen.Library.csproj
+++ b/model/Schemazen.Library.csproj
@@ -39,6 +39,11 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.SqlServer.ConnectionInfo, Version=12.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91, processorArchitecture=MSIL">
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.SqlServer.Management.Sdk.Sfc, Version=12.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91, processorArchitecture=MSIL" />
+    <Reference Include="Microsoft.SqlServer.Smo, Version=12.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91, processorArchitecture=MSIL" />
     <Reference Include="nunit.framework, Version=3.6.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.3.6.0\lib\net35\nunit.framework.dll</HintPath>
       <Private>True</Private>

--- a/model/Schemazen.Library.csproj
+++ b/model/Schemazen.Library.csproj
@@ -17,6 +17,7 @@
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
     <OldToolsVersion>3.5</OldToolsVersion>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -26,6 +27,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -34,8 +36,13 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="nunit.framework, Version=3.6.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.6.0\lib\net35\nunit.framework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.configuration" />
     <Reference Include="System.Core">
@@ -71,6 +78,8 @@
     <Compile Include="Models\Default.cs" />
     <Compile Include="Models\Exceptions.cs" />
     <Compile Include="Models\ForeignKey.cs" />
+    <Compile Include="Models\FullTextCatalog.cs" />
+    <Compile Include="Models\FullTextIndex.cs" />
     <Compile Include="Models\Identity.cs" />
     <Compile Include="Models\Interfaces.cs" />
     <Compile Include="Models\UserDefinedType.cs" />
@@ -82,6 +91,7 @@
     <Compile Include="Models\Table.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="packages.config" />
     <None Include="Schemazen.Library.nuspec" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/model/packages.config
+++ b/model/packages.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.SqlServer.ConnectionInfo.dll" version="1.0.1" targetFramework="net35" />
+  <package id="Microsoft.SqlServer.Management.Sdk.Sfc.dll" version="1.0.1" targetFramework="net35" />
+  <package id="Microsoft.SqlServer.Smo.dll" version="1.0.1" targetFramework="net35" />
+  <package id="NUnit" version="3.6.0" targetFramework="net35" />
+</packages>

--- a/test/AssemblyTester.cs
+++ b/test/AssemblyTester.cs
@@ -5,19 +5,16 @@ using SchemaZen.Library.Models;
 namespace SchemaZen.Tests {
 	[TestFixture]
 	public class AssemblyTester {
+		[Test]
+		[TestCase("SAFE_ACCESS", "SAFE")]
+		[TestCase("UNSAFE_ACCESS", "UNSAFE")]
+		[TestCase("EXTERNAL_ACCESS", "EXTERNAL_ACCESS")]
+		public void Assembly_WithPermissionSetCases(string permissionSet, string scriptedPermissionSet) {
+			var assembly = new SqlAssembly(permissionSet, "SchemazenAssembly");
+			assembly.Files.Add(new KeyValuePair<string, byte[]>("mydll", new byte[0]));
 
-        [Test]
-        [TestCase("SAFE_ACCESS", "SAFE")]
-        [TestCase("UNSAFE_ACCESS", "UNSAFE")]
-        [TestCase("EXTERNAL_ACCESS", "EXTERNAL_ACCESS")]
-        public void Assembly_WithPermissionSetCases(string permissionSet, string scriptedPermissionSet) {
-            var assembly = new SqlAssembly(permissionSet, "SchemazenAssembly");
-            assembly.Files.Add(new KeyValuePair<string, byte[]>("mydll", new byte[0]));
-
-		    var expected = @"CREATE ASSEMBLY [SchemazenAssembly]
-FROM 0x
-WITH PERMISSION_SET = " + scriptedPermissionSet;
-		    Assert.AreEqual(expected, assembly.ScriptCreate());
+			var expected = "CREATE ASSEMBLY [SchemazenAssembly]\r\nFROM 0x\r\nWITH PERMISSION_SET = " + scriptedPermissionSet;
+			Assert.AreEqual(expected, assembly.ScriptCreate());
 		}
 	}
 }

--- a/test/DatabaseTester.cs
+++ b/test/DatabaseTester.cs
@@ -657,7 +657,7 @@ select * from Table1
 			var copy = new Database("ScriptToDirTestCopy");
 			copy.Dir = db.Dir;
 			copy.Connection = ConfigHelper.TestDB.Replace("database=TESTDB", "database=" + copy.Name);
-			copy.CreateFromDir(true);
+			copy.CreateFromDir(true, false);
 			copy.Load();
 			TestCompare(db, copy);
 		}

--- a/test/TableTester.cs
+++ b/test/TableTester.cs
@@ -18,6 +18,7 @@ namespace SchemaZen.Tests {
 					lines[lines.Count - 1].Add(field);
 				}
 			}
+
 			////remove the \r from the end of the last field of each line
 			//foreach (List<string> line in lines) {
 			//    if (line.Count == 0) continue;
@@ -28,7 +29,6 @@ namespace SchemaZen.Tests {
 
 		[Test]
 		public void CompareConstraints() {
-
 			var t1 = new Table("dbo", "Test");
 			var t2 = new Table("dbo", "Test");
 			var diff = default(TableDiff);
@@ -43,7 +43,6 @@ namespace SchemaZen.Tests {
 			Assert.AreEqual(1, diff.ConstraintsChanged.Count);
 			Assert.IsNotNull(diff);
 			Assert.IsTrue(diff.IsDiff);
-
 		}
 
 		[Test]
@@ -104,11 +103,7 @@ namespace SchemaZen.Tests {
 			SqlConnection.ClearAllPools();
 			DBHelper.ExecBatchSql(conn, t.ScriptCreate());
 
-			var dataIn =
-				@"1	R	Ready
-2	P	Processing
-3	F	Frozen
-";
+			var dataIn = "1	R	Ready\r\n2	P	Processing\r\n3	F	Frozen\r\n";
 			var filename = Path.GetTempFileName();
 
 			var writer = File.AppendText(filename);
@@ -142,11 +137,7 @@ namespace SchemaZen.Tests {
 			SqlConnection.ClearAllPools();
 			DBHelper.ExecBatchSql(conn, t.ScriptCreate());
 
-			var dataIn =
-				@"1	R	Ready
-2	P	Processing
-3	F	Frozen
-";
+			var dataIn = "1	R	Ready\r\n2	P	Processing\r\n3	F	Frozen\r\n";
 			var filename = Path.GetTempFileName();
 
 			var writer = File.AppendText(filename);
@@ -159,7 +150,9 @@ namespace SchemaZen.Tests {
 				var sw = new StringWriter();
 				t.ExportData(conn, sw);
 				Assert.AreEqual(dataIn, sw.ToString());
-			} finally {
+			}
+
+			finally {
 				File.Delete(filename);
 			}
 		}
@@ -181,11 +174,7 @@ namespace SchemaZen.Tests {
 			DBHelper.ExecBatchSql(conn, s.ScriptCreate());
 			DBHelper.ExecBatchSql(conn, t.ScriptCreate());
 
-			var dataIn =
-				@"1	R	Ready
-2	P	Processing
-3	F	Frozen
-";
+			var dataIn = "1	R	Ready\r\n2	P	Processing\r\n3	F	Frozen\r\n";
 			var filename = Path.GetTempFileName();
 
 			var writer = File.AppendText(filename);
@@ -198,7 +187,9 @@ namespace SchemaZen.Tests {
 				var sw = new StringWriter();
 				t.ExportData(conn, sw);
 				Assert.AreEqual(dataIn, sw.ToString());
-			} finally {
+			}
+
+			finally {
 				File.Delete(filename);
 			}
 		}
@@ -238,7 +229,9 @@ namespace SchemaZen.Tests {
 				t.ExportData(conn, sw);
 
 				Assert.AreEqual(dataIn, sw.ToString());
-			} finally {
+			}
+
+			finally {
 				File.Delete(filename);
 			}
 		}

--- a/test/Tests.csproj
+++ b/test/Tests.csproj
@@ -124,6 +124,9 @@
   <ItemGroup>
     <Content Include="test_schemas\FK_REFS_NON_PK_COL.sql" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 


### PR DESCRIPTION
Added merge flag to allow running scripts (create) against an existing
database without needing to blow it away.

Added filterProps flag to allow filtering out database properties similar to filterTypes.

Switched create command to use SMO dlls instead of parsing the sql
blocks into executable chunks due to GO statements not being valid SQL.
This is because finding the GO statements was somewhat unreliable.

Due to the use of SMO dlls, an app.config is required for the executable
due to SMO dlls being mixed-mode assemblies. Added code that creates the
exe.config if it doesn't exist, so it won't be required to exist prior to running the app.

Added support for datetime2 and fixed precision loss on datetime
datatype columns.

Added support for scripting database to specific filegroups/files.

Added option to specify COLLATE on columns when scripting out the database.

Added support for Full-Text Indexes. 

Added option to ignore DUPLICATE KEY errors when importing data.

