### PR TITLE
Support constraints without name.

### DIFF
--- a/model/Models/Database.cs
+++ b/model/Models/Database.cs
@@ -528,7 +528,8 @@ from #ScriptedRoles
 						OBJECT_SCHEMA_NAME(fk.parent_object_id) as TABLE_SCHEMA,
 						UPDATE_RULE, 
 						DELETE_RULE,
-						fk.is_disabled
+						fk.is_disabled,
+                        fk.is_system_named
 					from INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS rc
 						inner join sys.foreign_keys fk on rc.CONSTRAINT_NAME = fk.name and rc.CONSTRAINT_SCHEMA = OBJECT_SCHEMA_NAME(fk.parent_object_id)";
 			using (var dr = cm.ExecuteReader()) {
@@ -537,6 +538,7 @@ from #ScriptedRoles
 					fk.OnUpdate = (string)dr["UPDATE_RULE"];
 					fk.OnDelete = (string)dr["DELETE_RULE"];
 					fk.Check = !(bool)dr["is_disabled"];
+				    fk.IsSystemNamed = (bool)dr["is_system_named"];
 				}
 			}
 
@@ -678,7 +680,8 @@ order by fk.name, fkc.constraint_column_id
 						t.name as TABLE_NAME, 
 						c.name as COLUMN_NAME, 
 						d.name as DEFAULT_NAME, 
-						d.definition as DEFAULT_VALUE
+						d.definition as DEFAULT_VALUE,
+                        d.is_system_named as IS_SYSTEM_NAMED
 					from sys.tables t 
 						inner join sys.columns c on c.object_id = t.object_id
 						inner join sys.default_constraints d on c.column_id = d.parent_column_id
@@ -688,7 +691,7 @@ order by fk.name, fkc.constraint_column_id
 				while (dr.Read()) {
 					var t = FindTable((string)dr["TABLE_NAME"], (string)dr["TABLE_SCHEMA"]);
 					t.Columns.Find((string)dr["COLUMN_NAME"]).Default = new Default((string)dr["DEFAULT_NAME"],
-						(string)dr["DEFAULT_VALUE"]);
+						(string)dr["DEFAULT_VALUE"], (bool)dr["IS_SYSTEM_NAMED"]);
 				}
 			}
 		}

--- a/model/Models/Default.cs
+++ b/model/Models/Default.cs
@@ -2,14 +2,16 @@
 	public class Default {
 		public string Name;
 		public string Value;
+	    public bool IsSystemNamed;
 
-		public Default(string name, string value) {
+	    public Default(string name, string value, bool isSystemNamed) {
 			Name = name;
 			Value = value;
-		}
+	        IsSystemNamed = isSystemNamed;
+	    }
 
 		public string ScriptAsPartOfColumnDefinition() {
-			return $"CONSTRAINT [{Name}] DEFAULT {Value}";
+		    return IsSystemNamed ? $" DEFAULT {Value}" : $"CONSTRAINT [{Name}] DEFAULT {Value}";
 		}
 
 		public string ScriptDrop() {

--- a/model/Models/ForeignKey.cs
+++ b/model/Models/ForeignKey.cs
@@ -6,7 +6,8 @@ using System.Text;
 namespace SchemaZen.Library.Models {
 	public class ForeignKey : INameable, IScriptable {
 		public bool Check { get; set; }
-		public List<string> Columns { get; set; } = new List<string>();
+        public bool IsSystemNamed { get; set; }
+        public List<string> Columns { get; set; } = new List<string>();
 		public string Name { get; set; }
 		public string OnDelete { get; set; }
 		public string OnUpdate { get; set; }
@@ -35,8 +36,8 @@ namespace SchemaZen.Library.Models {
 		}
 
 		public string CheckText => Check ? "CHECK" : "NOCHECK";
-
-		private void AssertArgNotNull(object arg, string argName) {
+	    
+	    private void AssertArgNotNull(object arg, string argName) {
 			if (arg == null) {
 				throw new ArgumentNullException($"Unable to Script FK {Name} on table {Table.Owner}.{Table.Name}. {argName} must not be null.");
 			}
@@ -49,7 +50,8 @@ namespace SchemaZen.Library.Models {
 			AssertArgNotNull(RefColumns, "RefColumns");
 
 			var text = new StringBuilder();
-			text.Append($"ALTER TABLE [{Table.Owner}].[{Table.Name}] WITH {CheckText} ADD CONSTRAINT [{Name}]\r\n");
+		    var constraintName = IsSystemNamed ? string.Empty : $"CONSTRAINT [{Name}]";
+			text.Append($"ALTER TABLE [{Table.Owner}].[{Table.Name}] WITH {CheckText} ADD {constraintName}\r\n");
 			text.Append($"   FOREIGN KEY([{string.Join("], [", Columns.ToArray())}]) REFERENCES [{RefTable.Owner}].[{RefTable.Name}] ([{string.Join("], [", RefColumns.ToArray())}])\r\n");
 			if (!string.IsNullOrEmpty(OnUpdate) && !_defaultRules.Split('|').Contains(OnUpdate)) {
 				text.Append($"   ON UPDATE {OnUpdate}\r\n");
@@ -57,10 +59,10 @@ namespace SchemaZen.Library.Models {
 			if (!string.IsNullOrEmpty(OnDelete) && !_defaultRules.Split('|').Contains(OnDelete)) {
 				text.Append($"   ON DELETE {OnDelete}\r\n");
 			}
-			if (!Check) {
-				text.Append($"   ALTER TABLE [{Table.Owner}].[{Table.Name}] NOCHECK CONSTRAINT [{Name}]\r\n");
-			}
-			return text.ToString();
+            if (!Check && !IsSystemNamed) {
+                text.Append($"   ALTER TABLE [{Table.Owner}].[{Table.Name}] NOCHECK CONSTRAINT [{Name}]\r\n");
+            }
+            return text.ToString();
 		}
 
 		public string ScriptDrop() {

--- a/test/ColumnTester.cs
+++ b/test/ColumnTester.cs
@@ -35,7 +35,16 @@ namespace SchemaZen.Tests {
 				Assert.AreEqual("[test] [int] NULL", lines[0]);
 				Assert.AreEqual("      CONSTRAINT [df_test] DEFAULT 0", lines[1]);
 			}
-			
-		}
+
+            [Test]
+            public void no_trailing_space_with_no_name_default()
+            {
+                var c = new Column("test", "int", true, new Default("df_ABCDEF", "0", true));
+                var lines = c.ScriptCreate().Split(new[] { Environment.NewLine }, StringSplitOptions.None);
+                Assert.AreEqual("[test] [int] NULL", lines[0]);
+                Assert.AreEqual("       DEFAULT 0", lines[1]);
+            }
+
+        }
 	}
 }

--- a/test/ColumnTester.cs
+++ b/test/ColumnTester.cs
@@ -30,7 +30,7 @@ namespace SchemaZen.Tests {
 
 			[Test]
 			public void no_trailing_space_with_default() {
-				var c = new Column("test", "int", true, new Default("df_test", "0"));
+				var c = new Column("test", "int", true, new Default("df_test", "0", false));
 				var lines = c.ScriptCreate().Split(new []{Environment.NewLine}, StringSplitOptions.None);
 				Assert.AreEqual("[test] [int] NULL", lines[0]);
 				Assert.AreEqual("      CONSTRAINT [df_test] DEFAULT 0", lines[1]);

--- a/test/TableTester.cs
+++ b/test/TableTester.cs
@@ -323,7 +323,7 @@ namespace SchemaZen.Tests {
 			t.Columns.Add(new Column("x", "uniqueidentifier", false, null));
 			t.Columns.Add(new Column("y", "varbinary", 50, false, null));
 			t.Columns.Add(new Column("z", "varbinary", -1, false, null));
-			t.Columns.Add(new Column("aa", "varchar", 50, true, new Default("DF_AllTypesTest_aa", "'asdf'")));
+			t.Columns.Add(new Column("aa", "varchar", 50, true, new Default("DF_AllTypesTest_aa", "'asdf'", false)));
 			t.Columns.Add(new Column("bb", "varchar", -1, true, null));
 			t.Columns.Add(new Column("cc", "xml", true, null));
 			t.Columns.Add(new Column("dd", "hierarchyid", false, null));


### PR DESCRIPTION
Allow default constraints and foreign key constraints with no constraint names. We can tell if the constraint name is system generated by inspecting the is_system_named attribute of sys.default_constraints and sys.foreign_keys