### PR TITLE
Avoid extra new line characters from being added

### DIFF
--- a/model/Models/Routine.cs
+++ b/model/Models/Routine.cs
@@ -67,13 +67,35 @@ namespace SchemaZen.Library.Models {
 				after +=
 						$"{Environment.NewLine}{(Disabled ? "DISABLE" : "ENABLE")} TRIGGER [{Owner}].[{Name}] ON [{RelatedTableSchema}].[{RelatedTableName}]{Environment.NewLine}GO{Environment.NewLine}";
 
-			if (string.IsNullOrEmpty(definition))
-				definition = $"/* missing definition for {RoutineType} [{Owner}].[{Name}] */";
+		    if (string.IsNullOrEmpty(definition))
+		        definition = $"/* missing definition for {RoutineType} [{Owner}].[{Name}] */";
+		    else
+		        definition = RemoveExtraNewLines(definition);
 
 			return before + definition + after;
 		}
 
-		public string ScriptCreate() {
+	    private static string RemoveExtraNewLines(string definition) {
+	        int startIndex = 0;
+	        int length = definition.Length;
+
+            if (definition.StartsWith(Environment.NewLine)) {
+                startIndex += Environment.NewLine.Length;
+            }
+
+            if (definition.EndsWith(Environment.NewLine))
+            {
+                length -= Environment.NewLine.Length;
+            }
+
+	        if (length - startIndex == definition.Length) {
+	            return definition;
+	        }
+
+	        return definition.Substring(startIndex, length);
+	    }
+
+	    public string ScriptCreate() {
 			return ScriptBase(Db, Text);
 		}
 

--- a/model/Models/Routine.cs
+++ b/model/Models/Routine.cs
@@ -76,23 +76,7 @@ namespace SchemaZen.Library.Models {
 		}
 
 	    private static string RemoveExtraNewLines(string definition) {
-	        int startIndex = 0;
-	        int length = definition.Length;
-
-            if (definition.StartsWith(Environment.NewLine)) {
-                startIndex += Environment.NewLine.Length;
-            }
-
-            if (definition.EndsWith(Environment.NewLine))
-            {
-                length -= Environment.NewLine.Length;
-            }
-
-	        if (length - startIndex == definition.Length) {
-	            return definition;
-	        }
-
-	        return definition.Substring(startIndex, length);
+	        return definition.Trim('\r', '\n');
 	    }
 
 	    public string ScriptCreate() {

--- a/model/Models/Routine.cs
+++ b/model/Models/Routine.cs
@@ -45,14 +45,14 @@ namespace SchemaZen.Library.Models {
 				defaultQuotedId = db.FindProp("QUOTED_IDENTIFIER").Value == "ON";
 			}
 			if (defaultQuotedId != QuotedId) {
-				script += $"SET QUOTED_IDENTIFIER {((databaseDefaults ? defaultQuotedId : QuotedId) ? "ON" : "OFF")} {Environment.NewLine}GO";
+				script += $"SET QUOTED_IDENTIFIER {((databaseDefaults ? defaultQuotedId : QuotedId) ? "ON" : "OFF")} {Environment.NewLine}GO{Environment.NewLine}";
 			}
 			var defaultAnsiNulls = !AnsiNull;
 			if (db?.FindProp("ANSI_NULLS") != null) {
 				defaultAnsiNulls = db.FindProp("ANSI_NULLS").Value == "ON";
 			}
 			if (defaultAnsiNulls != AnsiNull) {
-			    script += (script != "" ? Environment.NewLine : "") + $"SET ANSI_NULLS {((databaseDefaults ? defaultAnsiNulls : AnsiNull) ? "ON" : "OFF")} {Environment.NewLine}GO";
+				script += $"SET ANSI_NULLS {((databaseDefaults ? defaultAnsiNulls : AnsiNull) ? "ON" : "OFF")} {Environment.NewLine}GO{Environment.NewLine}";
 			}
 			return script;
 		}
@@ -61,7 +61,7 @@ namespace SchemaZen.Library.Models {
 			var before = ScriptQuotedIdAndAnsiNulls(db, false);
 			var after = ScriptQuotedIdAndAnsiNulls(db, true);
 			if (!string.IsNullOrEmpty(after))
-				after = "GO" + Environment.NewLine + after;
+				after = Environment.NewLine + "GO" + Environment.NewLine + after;
 
 			if (RoutineType == RoutineKind.Trigger)
 				after +=
@@ -70,7 +70,7 @@ namespace SchemaZen.Library.Models {
 			if (string.IsNullOrEmpty(definition))
 				definition = $"/* missing definition for {RoutineType} [{Owner}].[{Name}] */";
 
-			return before + definition + after + Environment.NewLine;
+			return before + definition + after;
 		}
 
 		public string ScriptCreate() {

--- a/model/Models/Routine.cs
+++ b/model/Models/Routine.cs
@@ -45,14 +45,14 @@ namespace SchemaZen.Library.Models {
 				defaultQuotedId = db.FindProp("QUOTED_IDENTIFIER").Value == "ON";
 			}
 			if (defaultQuotedId != QuotedId) {
-				script += $"SET QUOTED_IDENTIFIER {((databaseDefaults ? defaultQuotedId : QuotedId) ? "ON" : "OFF")} {Environment.NewLine}GO{Environment.NewLine}";
+				script += $"SET QUOTED_IDENTIFIER {((databaseDefaults ? defaultQuotedId : QuotedId) ? "ON" : "OFF")} {Environment.NewLine}GO";
 			}
 			var defaultAnsiNulls = !AnsiNull;
 			if (db?.FindProp("ANSI_NULLS") != null) {
 				defaultAnsiNulls = db.FindProp("ANSI_NULLS").Value == "ON";
 			}
 			if (defaultAnsiNulls != AnsiNull) {
-				script += $"SET ANSI_NULLS {((databaseDefaults ? defaultAnsiNulls : AnsiNull) ? "ON" : "OFF")} {Environment.NewLine}GO{Environment.NewLine}";
+			    script += (script != "" ? Environment.NewLine : "") + $"SET ANSI_NULLS {((databaseDefaults ? defaultAnsiNulls : AnsiNull) ? "ON" : "OFF")} {Environment.NewLine}GO";
 			}
 			return script;
 		}
@@ -61,7 +61,7 @@ namespace SchemaZen.Library.Models {
 			var before = ScriptQuotedIdAndAnsiNulls(db, false);
 			var after = ScriptQuotedIdAndAnsiNulls(db, true);
 			if (!string.IsNullOrEmpty(after))
-				after = Environment.NewLine + "GO" + Environment.NewLine + after;
+				after = "GO" + Environment.NewLine + after;
 
 			if (RoutineType == RoutineKind.Trigger)
 				after +=
@@ -70,7 +70,7 @@ namespace SchemaZen.Library.Models {
 			if (string.IsNullOrEmpty(definition))
 				definition = $"/* missing definition for {RoutineType} [{Owner}].[{Name}] */";
 
-			return before + definition + after;
+			return before + definition + after + Environment.NewLine;
 		}
 
 		public string ScriptCreate() {


### PR DESCRIPTION
Observed that extra new line characters are added before and after the definition of views, functions and stored procedures body.

The fix try to avoid that from happening