### PR TITLE
Random orderd constraints

### DIFF
--- a/model/Models/Comparers/ForeignKeyComparer.cs
+++ b/model/Models/Comparers/ForeignKeyComparer.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace SchemaZen.Library.Models.Comparers
+{
+    public class ForeignKeyComparer : IComparer<ForeignKey>
+    {
+        public static ForeignKeyComparer Instance { get; } = new ForeignKeyComparer();
+
+        public int Compare(ForeignKey x, ForeignKey y)
+        {
+            var result = string.Compare(x.Table.Owner, y.Table.Owner, StringComparison.Ordinal);
+
+            if (result != 0)
+            {
+                return result;
+            }
+
+            result = string.Compare(x.Table.Name, y.Table.Name, StringComparison.Ordinal);
+
+            if (result != 0)
+            {
+                return result;
+            }
+
+            for (var i = 0; i < x.Columns.Count; i++)
+            {
+                result = string.Compare(x.Columns[i], y.Columns[i], StringComparison.Ordinal);
+                if (result != 0)
+                {
+                    return result;
+                }
+            }
+
+            for (var i = 0; i < x.RefColumns.Count; i++)
+            {
+                result = string.Compare(x.RefColumns[i], y.RefColumns[i], StringComparison.Ordinal);
+                if (result != 0)
+                {
+                    return result;
+                }
+            }
+
+            return string.Compare(x.Name, y.Name, StringComparison.Ordinal);
+        }
+    }
+}

--- a/model/Models/Comparers/ForeignKeyComparer.cs
+++ b/model/Models/Comparers/ForeignKeyComparer.cs
@@ -23,6 +23,13 @@ namespace SchemaZen.Library.Models.Comparers
                 return result;
             }
 
+            result = x.Columns.Count.CompareTo(y.Columns.Count);
+
+            if (result != 0)
+            {
+                return result;
+            }
+
             for (var i = 0; i < x.Columns.Count; i++)
             {
                 result = string.Compare(x.Columns[i], y.Columns[i], StringComparison.Ordinal);
@@ -30,6 +37,13 @@ namespace SchemaZen.Library.Models.Comparers
                 {
                     return result;
                 }
+            }
+
+            result = x.RefColumns.Count.CompareTo(y.RefColumns.Count);
+
+            if (result != 0)
+            {
+                return result;
             }
 
             for (var i = 0; i < x.RefColumns.Count; i++)

--- a/model/Models/Database.cs
+++ b/model/Models/Database.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
+using SchemaZen.Library.Models.Comparers;
 
 namespace SchemaZen.Library.Models {
 	public class Database {
@@ -1155,7 +1156,7 @@ where name = @dbname
 			text.AppendLine();
 			text.AppendLine("GO");
 
-			foreach (var fk in ForeignKeys) {
+			foreach (var fk in ForeignKeys.OrderBy(f => f, ForeignKeyComparer.Instance)) {
 				text.AppendLine(fk.ScriptCreate());
 			}
 			text.AppendLine();

--- a/model/Models/Database.cs
+++ b/model/Models/Database.cs
@@ -1219,7 +1219,7 @@ where name = @dbname
 			WriteScriptDir("tables", Tables.ToArray(), log);
 			WriteScriptDir("table_types", TableTypes.ToArray(), log);
 			WriteScriptDir("user_defined_types", UserDefinedTypes.ToArray(), log);
-			WriteScriptDir("foreign_keys", ForeignKeys.OrderBy(x => x.Name).ToArray(), log);
+			WriteScriptDir("foreign_keys", ForeignKeys.OrderBy(x => x, ForeignKeyComparer.Instance).ToArray(), log);
 			foreach (var routineType in Routines.GroupBy(x => x.RoutineType)) {
 				var dir = routineType.Key.ToString().ToLower() + "s";
 				WriteScriptDir(dir, routineType.ToArray(), log);

--- a/model/Schemazen.Library.csproj
+++ b/model/Schemazen.Library.csproj
@@ -63,6 +63,7 @@
     <Compile Include="Models\Column.cs" />
     <Compile Include="Models\ColumnList.cs" />
     <Compile Include="ConfigHelper.cs" />
+    <Compile Include="Models\Comparers\ForeignKeyComparer.cs" />
     <Compile Include="Models\Constraint.cs" />
     <Compile Include="Models\ConstraintColumn.cs" />
     <Compile Include="Models\Database.cs" />


### PR DESCRIPTION
The order of the generated foreign keys can be random if the constraint names are auto generated.

The fix reduce the chance of random order by order the foreign key by schema name, table name, and column names instead of constraint names.
