### PR TITLE
Fix minor issues around RowGuidColText and reserved keywords in database names

### DIFF
--- a/model/DBHelper.cs
+++ b/model/DBHelper.cs
@@ -63,13 +63,13 @@ namespace SchemaZen.Library {
 			if (databaseFilesPath != null) {
 				Directory.CreateDirectory(databaseFilesPath);
 				files = $@"ON 
-(NAME = {dbName},
+(NAME = '{dbName}',
     FILENAME = '{databaseFilesPath}\{dbName + Guid.NewGuid()}.mdf')
 LOG ON
-(NAME = {dbName}_log,
+(NAME = '{dbName}_log',
     FILENAME =  '{databaseFilesPath}\{dbName + Guid.NewGuid()}.ldf')";
 			}
-			ExecSql(cnBuilder.ToString(), "CREATE DATABASE [" + dbName + "]" + files);
+			ExecSql(cnBuilder.ToString(), "CREATE DATABASE [" + dbName + "] " + files);
 		}
 
 		public static bool DbExists(string conn) {

--- a/model/Models/Column.cs
+++ b/model/Models/Column.cs
@@ -57,7 +57,7 @@ namespace SchemaZen.Library.Models {
 			}
 		}
 
-		public string RowGuidColText => IsRowGuidCol ? "ROWGUIDCOL" : string.Empty;
+		public string RowGuidColText => IsRowGuidCol ? " ROWGUIDCOL " : string.Empty;
 
 		public ColumnDiff Compare(Column c) {
 			return new ColumnDiff(this, c);
@@ -98,7 +98,7 @@ namespace SchemaZen.Library.Models {
 					val.Append($" {IsNullableText}");
 					if (includeDefaultConstraint) val.Append(DefaultText);
 					if (Identity != null) val.Append(IdentityText);
-					if (IsRowGuidCol) val.Append(@" {RowGuidColText}");
+					if (IsRowGuidCol) val.Append(RowGuidColText);
 					return val.ToString();
 
 				case "binary":


### PR DESCRIPTION
Ran into an edge case and noticed my definition would fail to create.

I reduced the test database to the following example:

CREATE DATABASE [rowguidcol]
go
CREATE TABLE [dbo].[Failure] (
[NodeGUID] [uniqueidentifier] NOT NULL default (newsequentialid()) ROWGUIDCOL,
)

Produced a create statement with ROWGUIDCOL replaced with {RowGuidColText}, I did not do extensive testing on this fix, but this looks right.

I also had a failure during this process as the filename for the generated database did not quote the logical name, which is fine except for when it contains a reserved keyword.
