### PR TITLE
Update Users create script to handle hyphens in username

### DIFF
--- a/model/Models/SqlUser.cs
+++ b/model/Models/SqlUser.cs
@@ -21,10 +21,10 @@ namespace SchemaZen.Library.Models {
 
 		public string ScriptCreate() {
 			var login = PasswordHash == null ? string.Empty : $@"IF SUSER_ID('{Name}') IS NULL
-				BEGIN CREATE LOGIN {Name} WITH PASSWORD = {"0x" + new SoapHexBinary(PasswordHash)} HASHED END
+				BEGIN CREATE LOGIN [{Name}] WITH PASSWORD = {"0x" + new SoapHexBinary(PasswordHash)} HASHED END
 ";
 
-			return login + $"CREATE USER [{Name}] {(PasswordHash == null ? "WITHOUT LOGIN" : "FOR LOGIN " + Name)} {(string.IsNullOrEmpty(Owner) ? string.Empty : "WITH DEFAULT_SCHEMA = ")}{Owner}"
+			return login + $"CREATE USER [{Name}] {(PasswordHash == null ? "WITHOUT LOGIN" : "FOR LOGIN [" + Name + "]")} {(string.IsNullOrEmpty(Owner) ? string.Empty : "WITH DEFAULT_SCHEMA = ")}{Owner}"
 				   + "\r\n" +
 				   string.Join("\r\n",
 					   DatabaseRoles.Select(


### PR DESCRIPTION
Current build contains a bug where a user with hyphen(s) in their name fails to be created during SchemaZen.exe create" run