### PR TITLE
fix yes on overwrite prompt

### DIFF
--- a/console/Script.cs
+++ b/console/Script.cs
@@ -48,6 +48,7 @@ namespace SchemaZen.console {
 			if (!Overwrite && Directory.Exists(ScriptDir)) {
 				if (!ConsoleQuestion.AskYN($"{ScriptDir} already exists - do you want to replace it"))
 					return 1;
+				Overwrite = true;
 			}
 
 			var scriptCommand = new ScriptCommand {


### PR DESCRIPTION
If a folder already exists but the `--overwrite` argument is omitted then the application prompts the user asking if they want to overwrite it. If the user says yes then it still fails as if they said no.