### PR TITLE
Fixing table type defaults missing, simplify and fix ANSI NULLS and QUOTED IDENTIFIER

### DIFF
--- a/model/Models/Routine.cs
+++ b/model/Models/Routine.cs
@@ -51,7 +51,7 @@ namespace SchemaZen.Library.Models {
 
 			if (defaultQuotedId != QuotedId) {
 				script +=
-					$"SET QUOTED_IDENTIFIER {(databaseDefaults ? defaultQuotedId : QuotedId ? "ON" : "OFF")} {Environment.NewLine}GO{Environment.NewLine}";
+					$"SET QUOTED_IDENTIFIER {(QuotedId ? "ON" : "OFF")} {Environment.NewLine}GO{Environment.NewLine}";
 			}
 
 			var defaultAnsiNulls = !AnsiNull;
@@ -61,7 +61,7 @@ namespace SchemaZen.Library.Models {
 
 			if (defaultAnsiNulls != AnsiNull) {
 				script +=
-					$"SET ANSI_NULLS {(databaseDefaults ? defaultAnsiNulls : AnsiNull ? "ON" : "OFF")} {Environment.NewLine}GO{Environment.NewLine}";
+					$"SET ANSI_NULLS {(AnsiNull ? "ON" : "OFF")} {Environment.NewLine}GO{Environment.NewLine}";
 			}
 
 			return script;


### PR DESCRIPTION
When exporting user defined table types with default values - eg
```
CREATE TYPE [dbo].[tvp_example] AS TABLE (
   [Title] [varchar](255) NOT NULL,
   [TotalCount] [int] NOT NULL
       DEFAULT ((0))
)
```
The default values will not be scripted out - found this was an issue with LoadColumnDefaults addressing tables only, not including table types. 

Additionally, there was a ternary operator with a few things to check, but after looking at the previous if statements, we would either always use the setting (because we have no database property) or we would gather it and want to show it if it is the opposite of the database, in which case the additional comparisons are not needed.  