### PR TITLE
Added support for computed columns in user-defined table-types.

### DIFF
--- a/model/Models/Database.cs
+++ b/model/Models/Database.cs
@@ -714,19 +714,37 @@ order by fk.name, fkc.constraint_column_id
 			//get computed column definitions
 			cm.CommandText = @"
 					select
-						object_schema_name(object_id) as TABLE_SCHEMA,
-						object_name(object_id) as TABLE_NAME,
-						name as COLUMN_NAME,
-						definition as DEFINITION,
-						is_persisted as PERSISTED
+						object_schema_name(t.object_id) as TABLE_SCHEMA,
+						object_name(t.object_id) as TABLE_NAME,
+						cc.name as COLUMN_NAME,
+						cc.definition as DEFINITION,
+						cc.is_persisted as PERSISTED,
+						cc.is_nullable as NULLABLE,
+						cast(0 as bit) as IS_TYPE
 					from sys.computed_columns cc
+					inner join sys.tables t on cc.object_id = t.object_id
+					UNION ALL
+					select 
+						SCHEMA_NAME(tt.schema_id) as TABLE_SCHEMA,
+						tt.name as TABLE_NAME,
+						cc.name as COLUMN_NAME,
+						cc.definition as DEFINITION,
+						cc.is_persisted as PERSISTED,
+						cc.is_nullable as NULLABLE,
+						cast(1 as bit) AS IS_TYPE
+					from sys.computed_columns cc
+					inner join sys.table_types tt on cc.object_id = tt.type_table_object_id
 					";
 			using (var dr = cm.ExecuteReader()) {
 				while (dr.Read()) {
-					var t = FindTable((string)dr["TABLE_NAME"], (string)dr["TABLE_SCHEMA"]);
-					var column = t.Columns.Find((string)dr["COLUMN_NAME"]);
-					column.ComputedDefinition = (string)dr["DEFINITION"];
-					column.Persisted = (bool)dr["PERSISTED"];
+					var t = FindTable((string)dr["TABLE_NAME"], (string)dr["TABLE_SCHEMA"], (bool)dr["IS_TYPE"]);
+					if (t != null) {
+						var column = t.Columns.Find((string)dr["COLUMN_NAME"]);
+						if (column != null) {
+							column.ComputedDefinition = (string)dr["DEFINITION"];
+							column.Persisted = (bool)dr["PERSISTED"];
+						}
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Added support for scripting computed columns on table types. Also fixed an issue that would result in a null ref exception if computed column query were to return a column in a table not contained in the 'Tables' or 'TableTypes' collection; basically this is just a null check and will result in those columns being excluded if the corresponding table doesn't exist in the collection.