### PR TITLE
Default and check-constraint generation changes

### DIFF
--- a/model/Models/Column.cs
+++ b/model/Models/Column.cs
@@ -17,19 +17,19 @@ namespace SchemaZen.Library.Models {
 
 		public Column() { }
 
-				public Column(string name, string type, bool nullable, Default defaultValue) {
+		public Column(string name, string type, bool nullable, Default defaultValue) {
 			Name = name;
 			Type = type;
 			Default = defaultValue;
 			IsNullable = nullable;
 		}
 
-				public Column(string name, string type, int length, bool nullable, Default defaultValue)
+		public Column(string name, string type, int length, bool nullable, Default defaultValue)
 			: this(name, type, nullable, defaultValue) {
 			Length = length;
 		}
 
-				public Column(string name, string type, byte precision, int scale, bool nullable,
+		public Column(string name, string type, byte precision, int scale, bool nullable,
 			Default defaultValue)
 			: this(name, type, nullable, defaultValue) {
 			Precision = precision;

--- a/model/Models/Constraint.cs
+++ b/model/Models/Constraint.cs
@@ -13,7 +13,10 @@ namespace SchemaZen.Library.Models {
 		public string Filter { get; set; }
 		public bool Unique { get; set; }
 		private bool _isNotForReplication;
+		private bool _isSystemNamed;
 		public string CheckConstraintExpression { get; private set; }
+
+		public bool ScriptInline { get { return Table == null || (Table != null && Table.IsType); } }
 
 		public Constraint(string name, string type, string columns) {
 			Name = name;
@@ -24,10 +27,11 @@ namespace SchemaZen.Library.Models {
 			}
 		}
 
-		public static Constraint CreateCheckedConstraint(string name, bool isNotForReplication,
+		public static Constraint CreateCheckedConstraint(string name, bool isNotForReplication, bool isSystemNamed,
 			string checkConstraintExpression) {
 			var constraint = new Constraint(name, "CHECK", "") {
 				_isNotForReplication = isNotForReplication,
+				_isSystemNamed = isSystemNamed,
 				CheckConstraintExpression = checkConstraintExpression
 			};
 			return constraint;
@@ -39,8 +43,11 @@ namespace SchemaZen.Library.Models {
 			switch (Type) {
 				case "CHECK":
 					var notForReplicationOption = _isNotForReplication ? "NOT FOR REPLICATION" : "";
-					return
-						$"CONSTRAINT [{Name}] CHECK {notForReplicationOption} {CheckConstraintExpression}";
+					if (ScriptInline) {
+						return $"CHECK {notForReplicationOption} {CheckConstraintExpression}";
+					} else {
+						return $"ALTER TABLE [{Table.Owner}].[{Table.Name}] WITH CHECK ADD {(_isSystemNamed ? string.Empty : $"CONSTRAINT [{Name}]")} CHECK {notForReplicationOption} {CheckConstraintExpression}";
+					}
 				case "INDEX":
 					var sql =
 						$"CREATE{UniqueText}{IndexType.Space()} INDEX [{Name}] ON [{Table.Owner}].[{Table.Name}] ({string.Join(", ", Columns.Select(c => c.Script()).ToArray())})";
@@ -55,7 +62,7 @@ namespace SchemaZen.Library.Models {
 					return sql;
 			}
 
-			return (Table.IsType ? string.Empty : $"CONSTRAINT [{Name}] ") +
+			return (Table.IsType || _isSystemNamed ? string.Empty : $"CONSTRAINT [{Name}] ") +
 				$"{Type}{IndexType.Space()} ({string.Join(", ", Columns.Select(c => c.Script()).ToArray())})";
 		}
 	}

--- a/model/Models/Default.cs
+++ b/model/Models/Default.cs
@@ -1,8 +1,12 @@
 ﻿namespace SchemaZen.Library.Models {
-	public class Default {
-		public string Name;
+	public class Default : IScriptable, INameable {
+		public string Name { get; set; }
 		public string Value;
 		public bool IsSystemNamed;
+		public Column Column;
+		public Table Table;
+
+		public bool ScriptInline { get { return Table == null || (Table != null && Table.IsType); } }
 
 		public Default(string name, string value, bool isSystemNamed) {
 			Name = name;
@@ -10,7 +14,15 @@
 			IsSystemNamed = isSystemNamed;
 		}
 
-		public string ScriptAsPartOfColumnDefinition() {
+		public Default(Table table, Column column, string name, string value, bool isSystemNamed) {
+			Name = name;
+			Value = value;
+			IsSystemNamed = isSystemNamed;
+			Column = column;
+			Table = table;
+		}
+
+		private string ScriptAsPartOfColumnDefinition() {
 			return IsSystemNamed ? $" DEFAULT {Value}" : $"CONSTRAINT [{Name}] DEFAULT {Value}";
 		}
 
@@ -18,8 +30,16 @@
 			return $"DROP CONSTRAINT [{Name}]";
 		}
 
+		public string ScriptCreate() {
+			if (ScriptInline) {
+				return ScriptAsPartOfColumnDefinition();
+			} else {
+				return ScriptCreate(Column);
+			}
+		}
+
 		public string ScriptCreate(Column column) {
-			return $"ADD {ScriptAsPartOfColumnDefinition()} FOR [{column.Name}]";
+			return $"ALTER TABLE [{Table.Owner}].[{Table.Name}] ADD {ScriptAsPartOfColumnDefinition()} FOR [{column.Name}]";
 		}
 	}
 }

--- a/model/Models/Table.cs
+++ b/model/Models/Table.cs
@@ -146,10 +146,15 @@ end
 				$"CREATE {(IsType ? "TYPE" : "TABLE")} [{Owner}].[{Name}] {(IsType ? "AS TABLE " : string.Empty)}(\r\n");
 			text.Append(Columns.Script());
 			if (_constraints.Count > 0) text.AppendLine();
-			foreach (var c in _constraints.OrderBy(x => x.Name).Where(c => c.Type != "INDEX")) {
-				text.AppendLine("   ," + c.ScriptCreate());
+			if (!IsType) {
+				foreach (var c in _constraints.OrderBy(x => x.Name).Where(c => c.Type == "PRIMARY KEY" || c.Type == "UNIQUE")) {
+					text.AppendLine("   ," + c.ScriptCreate());
+				}
+			} else {
+				foreach (var c in _constraints.OrderBy(x => x.Name).Where(c => c.Type != "INDEX")) {
+					text.AppendLine("   ," + c.ScriptCreate());
+				}
 			}
-
 			text.AppendLine(")");
 			text.AppendLine();
 			foreach (var c in _constraints.Where(c => c.Type == "INDEX")) {

--- a/test/ConstraintTester.cs
+++ b/test/ConstraintTester.cs
@@ -70,9 +70,9 @@ namespace SchemaZen.Tests {
 
 			[Test]
 			public void check_constraint() {
-				var c = Constraint.CreateCheckedConstraint("test", true, "[a]>(1)");
+				var c = Constraint.CreateCheckedConstraint("test", true, false, "[a]>(1)");
 				Assert.AreEqual(
-					"CONSTRAINT [test] CHECK NOT FOR REPLICATION [a]>(1)",
+					"CHECK NOT FOR REPLICATION [a]>(1)",
 					c.ScriptCreate());
 			}
 		}

--- a/test/TableTester.cs
+++ b/test/TableTester.cs
@@ -37,9 +37,9 @@ namespace SchemaZen.Tests {
 			t1.Columns.Add(new Column("first", "varchar", 30, false, null));
 			t2.Columns.Add(new Column("first", "varchar", 30, false, null));
 			t1.AddConstraint(
-				Constraint.CreateCheckedConstraint("IsTomorrow", true, "fnTomorrow()"));
+				Constraint.CreateCheckedConstraint("IsTomorrow", true, false, "fnTomorrow()"));
 			t2.AddConstraint(
-				Constraint.CreateCheckedConstraint("IsTomorrow", false, "Tomorrow <> 1"));
+				Constraint.CreateCheckedConstraint("IsTomorrow", false, false, "Tomorrow <> 1"));
 
 			diff = t1.Compare(t2);
 			Assert.AreEqual(1, diff.ConstraintsChanged.Count);


### PR DESCRIPTION
Defaults and check constraints are now generated separately from their respective tables unless they are required to be inline as is the case with table types and system named objects. They will be generated in their own folders in a file with the same name as their corresponding table. This was needed due to the possibility that a default or a check-constraint my refer to columns in a table other than the one for which the constraint is being created.  In cases where inline constraints or defaults are necessary such as table-types or system named items, then the constraint will be created inline.
