### PR TITLE
Add options for timeout, schema restriction and dbo-prefixing

### DIFF
--- a/console/BaseCommand.cs
+++ b/console/BaseCommand.cs
@@ -29,6 +29,14 @@ namespace SchemaZen.console {
 				"f|databaseFilesPath=",
 				"Path to database data and log files.",
 				o => DatabaseFilesPath = o);
+			HasOption(
+			   "timeout=",
+			   "Number of seconds for sql command timeout.",
+			   o => Timeout = o);
+			HasOption(
+			   "noprefixdbo",
+			   "Do not prefix objects in the dbo schema with dbo in their filename (for backwards compatibility).",
+			   o => NoPrefixDbo = o != null);
 		}
 
 		protected string Server { get; set; }
@@ -40,5 +48,7 @@ namespace SchemaZen.console {
 		protected bool Overwrite { get; set; }
 		protected bool Verbose { get; set; }
 		protected string DatabaseFilesPath { get; set; }
+		protected string Timeout { get; set; }
+		protected bool NoPrefixDbo { get; set; }
 	}
 }

--- a/model/Command/BaseCommand.cs
+++ b/model/Command/BaseCommand.cs
@@ -13,9 +13,12 @@ namespace SchemaZen.Library.Command {
 		public string ScriptDir { get; set; }
 		public ILogger Logger { get; set; }
 		public bool Overwrite { get; set; }
+		public int Timeout { get; set; }
+		public bool PrefixDbo { get; set; }
 
-		public Database CreateDatabase(IList<string> filteredTypes = null) {
+		public Database CreateDatabase(IList<string> filteredTypes = null, IList<string> schemas = null) {
 			filteredTypes = filteredTypes ?? new List<string>();
+			schemas = schemas ?? new List<string>();
 
 			if (!string.IsNullOrEmpty(ConnectionString)) {
 				if (!string.IsNullOrEmpty(Server) ||
@@ -26,7 +29,7 @@ namespace SchemaZen.Library.Command {
 						"You must not provide both a connection string and a server/db/user/password");
 				}
 
-				return new Database(filteredTypes) {
+				return new Database(filteredTypes, schemas, PrefixDbo) {
 					Connection = ConnectionString,
 					Dir = ScriptDir
 				};
@@ -50,7 +53,7 @@ namespace SchemaZen.Library.Command {
 				builder.Password = Pass;
 			}
 
-			return new Database(filteredTypes) {
+			return new Database(filteredTypes, schemas, PrefixDbo) {
 				Connection = builder.ToString(),
 				Dir = ScriptDir
 			};

--- a/model/Command/CompareCommand.cs
+++ b/model/Command/CompareCommand.cs
@@ -10,8 +10,8 @@ namespace SchemaZen.Library.Command {
 		public string OutDiff { get; set; }
 
 		public bool Execute() {
-			var sourceDb = new Database();
-			var targetDb = new Database();
+			var sourceDb = new Database(prefix_dbo: PrefixDbo);
+			var targetDb = new Database(prefix_dbo: PrefixDbo);
 			sourceDb.Connection = Source;
 			targetDb.Connection = Target;
 			sourceDb.Load();

--- a/model/Command/ScriptCommand.cs
+++ b/model/Command/ScriptCommand.cs
@@ -6,21 +6,21 @@ using System.Linq;
 
 namespace SchemaZen.Library.Command {
 	public class ScriptCommand : BaseCommand {
-		public void Execute(Dictionary<string, string> namesAndSchemas, string dataTablesPattern,
+		public void Execute(Dictionary<string, string> dataTableNames, string dataTablesPattern,
 			string dataTablesExcludePattern,
-			string tableHint, List<string> filteredTypes) {
+			string tableHint, List<string> filteredTypes, List<string> schemas) {
 			if (!Overwrite && Directory.Exists(ScriptDir)) {
 				var message = $"{ScriptDir} already exists - you must set overwrite to true";
 				throw new InvalidOperationException(message);
 			}
 
-			var db = CreateDatabase(filteredTypes);
+			var db = CreateDatabase(filteredTypes, schemas);
 
 			Logger.Log(TraceLevel.Verbose, "Loading database schema...");
-			db.Load();
+			db.Load(Timeout);
 			Logger.Log(TraceLevel.Verbose, "Database schema loaded.");
 
-			foreach (var nameAndSchema in namesAndSchemas) {
+			foreach (var nameAndSchema in dataTableNames) {
 				AddDataTable(db, nameAndSchema.Key, nameAndSchema.Value);
 			}
 

--- a/model/Models/Database.cs
+++ b/model/Models/Database.cs
@@ -11,9 +11,14 @@ using SchemaZen.Library.Models.Comparers;
 
 namespace SchemaZen.Library.Models {
 	public class Database {
+
+		private IList<string> schemas = new List<string>();
+		private string schemaIn = "";
+		private bool prefix_dbo = true;
+
 		#region " Constructors "
 
-		public Database(IList<string> filteredTypes = null) {
+		public Database(IList<string> filteredTypes = null, IList<string> schemas = null, bool prefix_dbo = true) {
 			Props.Add(new DbProp("COMPATIBILITY_LEVEL", ""));
 			Props.Add(new DbProp("COLLATE", ""));
 			Props.Add(new DbProp("AUTO_CLOSE", ""));
@@ -45,10 +50,13 @@ namespace SchemaZen.Library.Models {
 			foreach (var filteredType in filteredTypes) {
 				Dirs.Remove(filteredType);
 			}
+
+			this.schemas = schemas;
+			this.prefix_dbo = prefix_dbo;
 		}
 
-		public Database(string name, IList<string> filteredTypes = null)
-			: this(filteredTypes) {
+		public Database(string name, IList<string> filteredTypes = null, IList<string> schemas = null, bool prefix_dbo = true)
+			: this(filteredTypes, schemas, prefix_dbo) {
 			Name = name;
 		}
 
@@ -166,8 +174,11 @@ namespace SchemaZen.Library.Models {
 		#endregion
 
 		#region Load
-
 		public void Load() {
+			Load(30);
+		}
+
+		public void Load(int commandTimeout) {
 			Tables.Clear();
 			TableTypes.Clear();
 			Routines.Clear();
@@ -183,8 +194,13 @@ namespace SchemaZen.Library.Models {
 			using (var cn = new SqlConnection(Connection)) {
 				cn.Open();
 				using (var cm = cn.CreateCommand()) {
+					cm.CommandTimeout = commandTimeout;
 					LoadProps(cm);
 					LoadSchemas(cm);
+
+					schemas = schemas.Union(new[] { "dbo" }).ToList();
+					schemaIn = "(" + string.Join(",", schemas.Select(s => $"'{s}'").ToArray()) + ")";
+
 					LoadTables(cm);
 					LoadUserDefinedTypes(cm);
 					LoadColumns(cm);
@@ -207,9 +223,10 @@ namespace SchemaZen.Library.Models {
 
 		private void LoadSynonyms(SqlCommand cm) {
 			try {
-				// get synonyms
-				cm.CommandText = @"
+				Console.WriteLine("-- Loading synonyms");
+				cm.CommandText = $@"
 						select object_schema_name(object_id) as schema_name, name as synonym_name, base_object_name
+						where object_schema_name(object_id) in {schemaIn}
 						from sys.synonyms";
 				using (var dr = cm.ExecuteReader()) {
 					while (dr.Read()) {
@@ -226,16 +243,16 @@ namespace SchemaZen.Library.Models {
 
 		private void LoadPermissions(SqlCommand cm) {
 			try {
-				// get permissions
+				Console.WriteLine("-- Loading Permissions");
 				// based on http://sql-articles.com/scripts/script-to-retrieve-security-information-sql-server-2005-and-above/
-				cm.CommandText = @"
+				cm.CommandText = $@"
 						select 
 								U.name as user_name, 
 								O.name as object_name,  
 								permission_name as permission
 						from sys.database_permissions
 						join sys.sysusers U on grantee_principal_id = uid 
-						join sys.sysobjects O on major_id = id ";
+						join sys.sysobjects O on major_id = id and object_schema_name(id) in {schemaIn}";
 				using (var dr = cm.ExecuteReader()) {
 					while (dr.Read()) {
 						var permission = new Permission((string)dr["user_name"],
@@ -249,6 +266,7 @@ namespace SchemaZen.Library.Models {
 		}
 
 		private void LoadRoles(SqlCommand cm) {
+			Console.WriteLine("-- Loading Roles");
 			//Roles are complicated.  This was adapted from https://dbaeyes.wordpress.com/2013/04/19/fully-script-out-a-mssql-database-role/
 			cm.CommandText = @"
 create table #ScriptedRoles (
@@ -365,7 +383,7 @@ from #ScriptedRoles
 		}
 
 		private void LoadUsersAndLogins(SqlCommand cm) {
-			// get users that have access to the database
+			Console.WriteLine("-- Loading Users");
 			cm.CommandText = @"
 				select dp.name as UserName, USER_NAME(drm.role_principal_id) as AssociatedDBRole, default_schema_name
 				from sys.database_principals dp
@@ -409,7 +427,7 @@ from #ScriptedRoles
 
 		private void LoadCLRAssemblies(SqlCommand cm) {
 			try {
-				// get CLR assemblies
+				Console.WriteLine("-- Loading CLR Assemblies");
 				cm.CommandText =
 					@"select a.name as AssemblyName, a.permission_set_desc, af.name as FileName, af.content
 						from sys.assemblies a
@@ -437,11 +455,11 @@ from #ScriptedRoles
 
 		private void LoadXmlSchemas(SqlCommand cm) {
 			try {
-				// get xml schemas
-				cm.CommandText = @"
+				Console.WriteLine("-- Loading Xml Schemas");
+				cm.CommandText = $@"
 						select s.name as DBSchemaName, x.name as XMLSchemaCollectionName, xml_schema_namespace(s.name, x.name) as definition
 						from sys.xml_schema_collections x
-						inner join sys.schemas s on s.schema_id = x.schema_id
+						inner join sys.schemas s on s.schema_id = x.schema_id and s.name in {schemaIn}
 						where s.name != 'sys'";
 				using (var dr = cm.ExecuteReader()) {
 					while (dr.Read()) {
@@ -462,8 +480,8 @@ from #ScriptedRoles
 		}
 
 		private void LoadRoutines(SqlCommand cm) {
-			//get routines
-			cm.CommandText = @"
+			Console.WriteLine("-- Loading Routines");
+			cm.CommandText = $@"
 					select
 						s.name as schemaName,
 						o.name as routineName,
@@ -476,7 +494,7 @@ from #ScriptedRoles
 						tr.is_disabled as trigger_disabled
 					from sys.sql_modules m
 						inner join sys.objects o on m.object_id = o.object_id
-						inner join sys.schemas s on s.schema_id = o.schema_id
+						inner join sys.schemas s on s.schema_id = o.schema_id and s.name in {schemaIn}
 						left join sys.triggers tr on m.object_id = tr.object_id
 						left join sys.tables t on tr.parent_id = t.object_id
 						left join sys.views v on tr.parent_id = v.object_id
@@ -516,7 +534,8 @@ from #ScriptedRoles
 		}
 
 		private void LoadCheckConstraints(SqlCommand cm) {
-			cm.CommandText = @"
+			Console.WriteLine("-- Loading Check Constraints");
+			cm.CommandText = $@"
 				SELECT 
 					OBJECT_NAME(o.OBJECT_ID) AS CONSTRAINT_NAME,
 					SCHEMA_NAME(t.schema_id) AS TABLE_SCHEMA,
@@ -529,7 +548,7 @@ from #ScriptedRoles
 				FROM sys.objects o
 					inner join sys.check_constraints cc on cc.object_id = o.object_id
 					inner join sys.tables t on t.object_id = o.parent_object_id
-					WHERE o.type_desc = 'CHECK_CONSTRAINT'
+					WHERE o.type_desc = 'CHECK_CONSTRAINT' and SCHEMA_NAME(t.schema_id) in {schemaIn}
 				UNION ALL
 				SELECT 
 					OBJECT_NAME(o.OBJECT_ID) AS CONSTRAINT_NAME,
@@ -543,7 +562,7 @@ from #ScriptedRoles
 				FROM sys.objects o
 					inner join sys.check_constraints cc on cc.object_id = o.object_id
 					inner join sys.table_types tt on tt.type_table_object_id = o.parent_object_id
-					WHERE o.type_desc = 'CHECK_CONSTRAINT'
+					WHERE o.type_desc = 'CHECK_CONSTRAINT' and SCHEMA_NAME(tt.schema_id) in {schemaIn}
 				ORDER BY TABLE_SCHEMA, TABLE_NAME, CONSTRAINT_NAME
 				";
 
@@ -565,14 +584,14 @@ from #ScriptedRoles
 		}
 
 		private void LoadForeignKeys(SqlCommand cm) {
-			//get foreign keys
-			cm.CommandText = @"
+			Console.WriteLine("-- Loading Foreign Keys");
+			cm.CommandText = $@"
 					select 
 						TABLE_SCHEMA,
 						TABLE_NAME, 
 						CONSTRAINT_NAME
 					from INFORMATION_SCHEMA.TABLE_CONSTRAINTS
-					where CONSTRAINT_TYPE = 'FOREIGN KEY'";
+					where CONSTRAINT_TYPE = 'FOREIGN KEY' and TABLE_SCHEMA in {schemaIn}";
 			using (var dr = cm.ExecuteReader()) {
 				while (dr.Read()) {
 					var t = FindTable((string)dr["TABLE_NAME"], (string)dr["TABLE_SCHEMA"]);
@@ -583,7 +602,7 @@ from #ScriptedRoles
 			}
 
 			//get foreign key props
-			cm.CommandText = @"
+			cm.CommandText = $@"
 					select 
 						CONSTRAINT_NAME, 
 						OBJECT_SCHEMA_NAME(fk.parent_object_id) as TABLE_SCHEMA,
@@ -592,7 +611,8 @@ from #ScriptedRoles
 						fk.is_disabled,
                         fk.is_system_named
 					from INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS rc
-						inner join sys.foreign_keys fk on rc.CONSTRAINT_NAME = fk.name and rc.CONSTRAINT_SCHEMA = OBJECT_SCHEMA_NAME(fk.parent_object_id)";
+						inner join sys.foreign_keys fk on rc.CONSTRAINT_NAME = fk.name and rc.CONSTRAINT_SCHEMA = OBJECT_SCHEMA_NAME(fk.parent_object_id)
+					where object_schema_name(fk.parent_object_id) in {schemaIn}";
 			using (var dr = cm.ExecuteReader()) {
 				while (dr.Read()) {
 					var fk = FindForeignKey((string)dr["CONSTRAINT_NAME"],
@@ -605,25 +625,26 @@ from #ScriptedRoles
 			}
 
 			//get foreign key columns and ref table
-			cm.CommandText = @"
-select
-	fk.name as CONSTRAINT_NAME,
-	OBJECT_SCHEMA_NAME(fk.parent_object_id) as TABLE_SCHEMA,
-	c1.name as COLUMN_NAME,
-	OBJECT_SCHEMA_NAME(fk.referenced_object_id) as REF_TABLE_SCHEMA,
-	OBJECT_NAME(fk.referenced_object_id) as REF_TABLE_NAME,
-	c2.name as REF_COLUMN_NAME
-from sys.foreign_keys fk
-inner join sys.foreign_key_columns fkc
-	on fkc.constraint_object_id = fk.object_id
-inner join sys.columns c1
-	on fkc.parent_column_id = c1.column_id
-	and fkc.parent_object_id = c1.object_id
-inner join sys.columns c2
-	on fkc.referenced_column_id = c2.column_id
-	and fkc.referenced_object_id = c2.object_id
-order by fk.name, fkc.constraint_column_id
-";
+			cm.CommandText = $@"
+				select
+					fk.name as CONSTRAINT_NAME,
+					OBJECT_SCHEMA_NAME(fk.parent_object_id) as TABLE_SCHEMA,
+					c1.name as COLUMN_NAME,
+					OBJECT_SCHEMA_NAME(fk.referenced_object_id) as REF_TABLE_SCHEMA,
+					OBJECT_NAME(fk.referenced_object_id) as REF_TABLE_NAME,
+					c2.name as REF_COLUMN_NAME
+				from sys.foreign_keys fk
+				inner join sys.foreign_key_columns fkc
+					on fkc.constraint_object_id = fk.object_id
+				inner join sys.columns c1
+					on fkc.parent_column_id = c1.column_id
+					and fkc.parent_object_id = c1.object_id
+				inner join sys.columns c2
+					on fkc.referenced_column_id = c2.column_id
+					and fkc.referenced_object_id = c2.object_id
+				where object_schema_name(fk.parent_object_id) in {schemaIn}
+				order by fk.name, fkc.constraint_column_id
+				";
 			using (var dr = cm.ExecuteReader()) {
 				while (dr.Read()) {
 					var fk = FindForeignKey((string)dr["CONSTRAINT_NAME"],
@@ -643,8 +664,8 @@ order by fk.name, fkc.constraint_column_id
 		}
 
 		private void LoadConstraintsAndIndexes(SqlCommand cm) {
-			//get constraints & indexes
-			cm.CommandText = @"
+			Console.WriteLine("-- Loading Constraints/Indexes");
+			cm.CommandText = $@"
 					select 
 						s.name as schemaName,
 						t.name as tableName, 
@@ -674,7 +695,7 @@ order by fk.name, fkc.constraint_column_id
 							and ic.index_id = i.index_id
 						inner join sys.columns c on c.object_id = t.object_id
 							and c.column_id = ic.column_id
-						inner join sys.schemas s on s.schema_id = t.schema_id
+						inner join sys.schemas s on s.schema_id = t.schema_id and s.name in {schemaIn}
 					where i.type_desc != 'HEAP'
 					order by s.name, t.name, i.name, ic.key_ordinal, ic.index_column_id";
 			using (var dr = cm.ExecuteReader()) {
@@ -722,8 +743,8 @@ order by fk.name, fkc.constraint_column_id
 		}
 
 		private void LoadColumnComputes(SqlCommand cm) {
-			//get computed column definitions
-			cm.CommandText = @"
+			Console.WriteLine("-- Loading Computed Columns");
+			cm.CommandText = $@"
 					select
 						object_schema_name(t.object_id) as TABLE_SCHEMA,
 						object_name(t.object_id) as TABLE_NAME,
@@ -733,7 +754,7 @@ order by fk.name, fkc.constraint_column_id
 						cc.is_nullable as NULLABLE,
 						cast(0 as bit) as IS_TYPE
 					from sys.computed_columns cc
-					inner join sys.tables t on cc.object_id = t.object_id
+					inner join sys.tables t on cc.object_id = t.object_id and object_schema_name(t.object_id) in {schemaIn}
 					UNION ALL
 					select 
 						SCHEMA_NAME(tt.schema_id) as TABLE_SCHEMA,
@@ -744,7 +765,7 @@ order by fk.name, fkc.constraint_column_id
 						cc.is_nullable as NULLABLE,
 						cast(1 as bit) AS IS_TYPE
 					from sys.computed_columns cc
-					inner join sys.table_types tt on cc.object_id = tt.type_table_object_id
+					inner join sys.table_types tt on cc.object_id = tt.type_table_object_id and schema_name(tt.schema_id) in {schemaIn}
 					";
 			using (var dr = cm.ExecuteReader()) {
 				while (dr.Read()) {
@@ -761,8 +782,8 @@ order by fk.name, fkc.constraint_column_id
 		}
 
 		private void LoadColumnDefaults(SqlCommand cm) {
-			//get column defaults
-			cm.CommandText = @"
+			Console.WriteLine("-- Loading Column Defaults");
+			cm.CommandText = $@"
 					select 
 						s.name as TABLE_SCHEMA,
 						t.name as TABLE_NAME, 
@@ -775,7 +796,7 @@ order by fk.name, fkc.constraint_column_id
 						inner join sys.columns c on c.object_id = t.object_id
 						inner join sys.default_constraints d on c.column_id = d.parent_column_id
 							and d.parent_object_id = c.object_id
-						inner join sys.schemas s on s.schema_id = t.schema_id
+						inner join sys.schemas s on s.schema_id = t.schema_id and s.name in {schemaIn}
 					UNION ALL
 					select 
 						s.name as TABLE_SCHEMA,
@@ -789,7 +810,7 @@ order by fk.name, fkc.constraint_column_id
 						inner join sys.columns c on c.object_id = tt.type_table_object_id
 						inner join sys.default_constraints d on c.column_id = d.parent_column_id
 							and d.parent_object_id = c.object_id
-						inner join sys.schemas s on s.schema_id = tt.schema_id
+						inner join sys.schemas s on s.schema_id = tt.schema_id and s.name in {schemaIn}
 ";
 			using (var dr = cm.ExecuteReader()) {
 				while (dr.Read()) {
@@ -805,8 +826,8 @@ order by fk.name, fkc.constraint_column_id
 		}
 
 		private void LoadColumnIdentities(SqlCommand cm) {
-			//get column identities
-			cm.CommandText = @"
+			Console.WriteLine("-- Loading Column Identities");
+			cm.CommandText = $@"
 					select 
 						s.name as TABLE_SCHEMA,
 						t.name as TABLE_NAME, 
@@ -816,7 +837,7 @@ order by fk.name, fkc.constraint_column_id
 						inner join sys.columns c on c.object_id = t.object_id
 						inner join sys.identity_columns i on i.object_id = c.object_id
 							and i.column_id = c.column_id
-						inner join sys.schemas s on s.schema_id = t.schema_id ";
+						inner join sys.schemas s on s.schema_id = t.schema_id and s.name in {schemaIn}";
 			using (var dr = cm.ExecuteReader()) {
 				while (dr.Read()) {
 					try {
@@ -835,8 +856,8 @@ order by fk.name, fkc.constraint_column_id
 		}
 
 		private void LoadColumns(SqlCommand cm) {
-			//get columns
-			cm.CommandText = @"
+			Console.WriteLine("-- Loading Columns");
+			cm.CommandText = $@"
 				select 
 					t.TABLE_SCHEMA,
 					c.TABLE_NAME,
@@ -853,6 +874,7 @@ order by fk.name, fkc.constraint_column_id
 							on t.TABLE_NAME = c.TABLE_NAME
 								and t.TABLE_SCHEMA = c.TABLE_SCHEMA
 								and t.TABLE_CATALOG = c.TABLE_CATALOG
+								and t.TABLE_SCHEMA in {schemaIn}
 				where
 					t.TABLE_TYPE = 'BASE TABLE'
 				order by t.TABLE_SCHEMA, c.TABLE_NAME, c.ORDINAL_POSITION
@@ -862,7 +884,7 @@ order by fk.name, fkc.constraint_column_id
 			}
 
 			try {
-				cm.CommandText = @"
+				cm.CommandText = $@"
 				select 
 					s.name as TABLE_SCHEMA,
 					tt.name as TABLE_NAME, 
@@ -878,7 +900,7 @@ order by fk.name, fkc.constraint_column_id
 					inner join sys.table_types tt
 						on tt.type_table_object_id = c.object_id
 					inner join sys.schemas s
-						on tt.schema_id = s.schema_id 
+						on tt.schema_id = s.schema_id and s.name in {schemaIn}
 					inner join sys.types t
 						on t.system_type_id = c.system_type_id
 							and t.user_type_id = c.user_type_id
@@ -924,7 +946,7 @@ order by fk.name, fkc.constraint_column_id
 
 				if (table == null || table.Name != (string)dr["TABLE_NAME"] ||
 						table.Owner != (string)dr["TABLE_SCHEMA"])
-					// only do a lookup if the table we have isn't already the relevant one
+				// only do a lookup if the table we have isn't already the relevant one
 				{
 					table = FindTableBase(tables, (string)dr["TABLE_NAME"],
 						(string)dr["TABLE_SCHEMA"]);
@@ -935,25 +957,25 @@ order by fk.name, fkc.constraint_column_id
 		}
 
 		private void LoadTables(SqlCommand cm) {
-			//get tables
-			cm.CommandText = @"
+			Console.WriteLine("-- Loading Tables");
+			cm.CommandText = $@"
 				select 
 					TABLE_SCHEMA, 
 					TABLE_NAME 
 				from INFORMATION_SCHEMA.TABLES
-				where TABLE_TYPE = 'BASE TABLE'";
+				where TABLE_TYPE = 'BASE TABLE' and TABLE_SCHEMA  in {schemaIn}";
 			using (var dr = cm.ExecuteReader()) {
 				LoadTablesBase(dr, false, Tables);
 			}
 
 			//get table types
 			try {
-				cm.CommandText = @"
+				cm.CommandText = $@"
 				select 
 					s.name as TABLE_SCHEMA,
 					tt.name as TABLE_NAME
 				from sys.table_types tt
-				inner join sys.schemas s on tt.schema_id = s.schema_id
+				inner join sys.schemas s on tt.schema_id = s.schema_id and s.name in {schemaIn}
 				where tt.is_user_defined = 1
 				order by s.name, tt.name";
 				using (var dr = cm.ExecuteReader()) {
@@ -965,8 +987,8 @@ order by fk.name, fkc.constraint_column_id
 		}
 
 		private void LoadUserDefinedTypes(SqlCommand cm) {
-			//get types
-			cm.CommandText = @"
+			Console.WriteLine("-- Loading UDTs");
+			cm.CommandText = $@"
             select
                 s.name as 'Type_Schema',
                 t.name as 'Type_Name',
@@ -974,7 +996,7 @@ order by fk.name, fkc.constraint_column_id
                 t.max_length as 'Max_Length',
                 t.is_nullable as 'Nullable'	
             from sys.types t
-            inner join sys.schemas s on s.schema_id = t.schema_id
+            inner join sys.schemas s on s.schema_id = t.schema_id and s.name in {schemaIn}
             inner join sys.types tt on t.system_type_id = tt.user_type_id
             where
                 t.is_user_defined = 1
@@ -1005,19 +1027,27 @@ order by fk.name, fkc.constraint_column_id
 		}
 
 		private void LoadSchemas(SqlCommand cm) {
-			//get schemas
-			cm.CommandText = @"
+			Console.WriteLine("-- Loading Schemas");
+			var schemaRestrict = "";
+			if (schemas != null && schemas.Count > 0) {
+				schemaRestrict = "and s.name in (" + string.Join(",", schemas.Select(s => $"'{s}'").ToArray()) + ")";
+			}
+			cm.CommandText = $@"
 					select s.name as schemaName, p.name as principalName
 					from sys.schemas s
 					inner join sys.database_principals p on s.principal_id = p.principal_id
 					where s.schema_id < 16384
-					and s.name not in ('dbo','guest','sys','INFORMATION_SCHEMA')
-					order by schema_id
-";
+					and s.name not in ('dbo','guest','sys','INFORMATION_SCHEMA') {schemaRestrict}
+					order by schema_id";
+
 			using (var dr = cm.ExecuteReader()) {
 				while (dr.Read()) {
 					Schemas.Add(new Schema((string)dr["schemaName"], (string)dr["principalName"]));
 				}
+			}
+
+			if (schemas == null || schemas.Count == 0) {
+				schemas = Schemas.Select(s => s.Name).ToList();
 			}
 		}
 
@@ -1025,36 +1055,36 @@ order by fk.name, fkc.constraint_column_id
 			var cnStrBuilder = new SqlConnectionStringBuilder(Connection);
 			// query schema for database properties
 			cm.CommandText = @"
-select
-	[compatibility_level],
-	[collation_name],
-	[is_auto_close_on],
-	[is_auto_shrink_on],
-	[snapshot_isolation_state],
-	[is_read_committed_snapshot_on],
-	[recovery_model_desc],
-	[page_verify_option_desc],
-	[is_auto_create_stats_on],
-	[is_auto_update_stats_on],
-	[is_auto_update_stats_async_on],
-	[is_ansi_null_default_on],
-	[is_ansi_nulls_on],
-	[is_ansi_padding_on],
-	[is_ansi_warnings_on],
-	[is_arithabort_on],
-	[is_concat_null_yields_null_on],
-	[is_numeric_roundabort_on],
-	[is_quoted_identifier_on],
-	[is_recursive_triggers_on],
-	[is_cursor_close_on_commit_on],
-	[is_local_cursor_default],
-	[is_trustworthy_on],
-	[is_db_chaining_on],
-	[is_parameterization_forced],
-	[is_date_correlation_on]
-from sys.databases
-where name = @dbname
-";
+				select
+					[compatibility_level],
+					[collation_name],
+					[is_auto_close_on],
+					[is_auto_shrink_on],
+					[snapshot_isolation_state],
+					[is_read_committed_snapshot_on],
+					[recovery_model_desc],
+					[page_verify_option_desc],
+					[is_auto_create_stats_on],
+					[is_auto_update_stats_on],
+					[is_auto_update_stats_async_on],
+					[is_ansi_null_default_on],
+					[is_ansi_nulls_on],
+					[is_ansi_padding_on],
+					[is_ansi_warnings_on],
+					[is_arithabort_on],
+					[is_concat_null_yields_null_on],
+					[is_numeric_roundabort_on],
+					[is_quoted_identifier_on],
+					[is_recursive_triggers_on],
+					[is_cursor_close_on_commit_on],
+					[is_local_cursor_default],
+					[is_trustworthy_on],
+					[is_db_chaining_on],
+					[is_parameterization_forced],
+					[is_date_correlation_on]
+				from sys.databases
+				where name = @dbname
+				";
 			cm.Parameters.AddWithValue("@dbname", cnStrBuilder.InitialCatalog);
 			using (IDataReader dr = cm.ExecuteReader()) {
 				if (dr.Read()) {
@@ -1115,9 +1145,9 @@ where name = @dbname
 
 			//compare database properties		   
 			foreach (var p in from p in Props
-				let p2 = db.FindProp(p.Name)
-				where p.Script() != p2.Script()
-				select p) {
+							  let p2 = db.FindProp(p.Name)
+							  where p.Script() != p2.Script()
+							  select p) {
 				diff.PropsChanged.Add(p);
 			}
 
@@ -1407,7 +1437,7 @@ where name = @dbname
 			WriteScriptDir("synonyms", Synonyms.ToArray(), log);
 			WriteScriptDir("permissions", Permissions.ToArray(), log);
 
-			ExportData(tableHint, log);
+			ExportData(tableHint, prefix_dbo, log);
 		}
 
 		private void WritePropsScript(Action<TraceLevel, string> log) {
@@ -1443,31 +1473,31 @@ where name = @dbname
 			foreach (var o in objects) {
 				log(TraceLevel.Verbose,
 					$"Scripting {name} {++index} of {objects.Count}...{(index < objects.Count ? "\r" : string.Empty)}");
-				var filePath = Path.Combine(dir, MakeFileName(o) + ".sql");
+				var filePath = Path.Combine(dir, MakeFileName(o, prefix_dbo) + ".sql");
 				var script = o.ScriptCreate() + "\r\nGO\r\n";
 				File.AppendAllText(filePath, script);
 			}
 		}
 
-		private static string MakeFileName(object o) {
+		private static string MakeFileName(object o, bool prefix_dbo = true) {
 			// combine foreign keys into one script per table
 			var fk = o as ForeignKey;
-			if (fk != null) return MakeFileName(fk.Table);
+			if (fk != null) return MakeFileName(fk.Table, prefix_dbo);
 
 			// combine defaults into one script per table
 			if (o is Default) {
-				return MakeFileName((o as Default).Table);
+				return MakeFileName((o as Default).Table, prefix_dbo);
 			}
 
 			// combine check constraints into one script per table
 			if (o is Constraint && (o as Constraint).Type == "CHECK") {
-				return MakeFileName((o as Constraint).Table);
+				return MakeFileName((o as Constraint).Table, prefix_dbo);
 			}
 
 			var schema = o as IHasOwner == null ? "" : (o as IHasOwner).Owner;
 			var name = o as INameable == null ? "" : (o as INameable).Name;
 
-			var fileName = MakeFileName(schema, name);
+			var fileName = MakeFileName(schema, name, prefix_dbo);
 
 			// prefix user defined types with TYPE_
 			var prefix = o as Table == null ? "" : (o as Table).IsType ? "TYPE_" : "";
@@ -1475,12 +1505,12 @@ where name = @dbname
 			return string.Concat(prefix, fileName);
 		}
 
-		private static string MakeFileName(string schema, string name) {
+		private static string MakeFileName(string schema, string name, bool prefix_dbo = true) {
 			// Dont' include schema name for objects in the dbo schema.
 			// This maintains backward compatability for those who use
 			// SchemaZen to keep their schemas under version control.
 			var fileName = name;
-			if (!string.IsNullOrEmpty(schema) && schema.ToLower() != "dbo") {
+			if (!string.IsNullOrEmpty(schema) && (prefix_dbo || schema.ToLower() != "dbo")) {
 				fileName = $"{schema}.{name}";
 			}
 
@@ -1488,7 +1518,7 @@ where name = @dbname
 				(current, invalidChar) => current.Replace(invalidChar, '-'));
 		}
 
-		public void ExportData(string tableHint = null, Action<TraceLevel, string> log = null) {
+		public void ExportData(string tableHint = null, bool prefix_dbo = true, Action<TraceLevel, string> log = null) {
 			if (!DataTables.Any())
 				return;
 			var dataDir = Dir + "/data";
@@ -1501,7 +1531,7 @@ where name = @dbname
 			foreach (var t in DataTables) {
 				log?.Invoke(TraceLevel.Verbose,
 					$"Exporting data from {t.Owner + "." + t.Name} (table {++index} of {DataTables.Count})...");
-				var filePathAndName = dataDir + "/" + MakeFileName(t) + ".tsv";
+				var filePathAndName = dataDir + "/" + MakeFileName(t, prefix_dbo) + ".tsv";
 				var sw = File.CreateText(filePathAndName);
 				t.ExportData(Connection, sw, tableHint);
 

--- a/test/DatabaseTester.cs
+++ b/test/DatabaseTester.cs
@@ -317,7 +317,7 @@ CREATE TYPE [dbo].[MyTableType] AS TABLE(
 			Assert.AreEqual(-1,
 				db.TableTypes[0].Columns.Items[2].Length); //nvarchar(max) is encoded as -1
 			Assert.AreEqual("MyTableType", db.TableTypes[0].Name);
-			Assert.IsTrue(File.Exists(db.Name + "\\table_types\\TYPE_MyTableType.sql"));
+			Assert.IsTrue(File.Exists(db.Name + "\\table_types\\TYPE_dbo.MyTableType.sql"));
 		}
 
 		[Test]
@@ -352,9 +352,9 @@ CREATE TYPE [dbo].[MyTableType] AS TABLE(
 			Assert.AreEqual("ID", db.TableTypes[0].PrimaryKey.Columns[0].ColumnName);
 			Assert.AreEqual(50, db.TableTypes[0].Columns.Items[1].Length);
 			Assert.AreEqual("MyTableType", db.TableTypes[0].Name);
-			Assert.IsTrue(File.Exists(db.Name + "\\table_types\\TYPE_MyTableType.sql"));
+			Assert.IsTrue(File.Exists(db.Name + "\\table_types\\TYPE_dbo.MyTableType.sql"));
 
-			Assert.IsTrue(File.ReadAllText(db.Name + "\\table_types\\TYPE_MyTableType.sql")
+			Assert.IsTrue(File.ReadAllText(db.Name + "\\table_types\\TYPE_dbo.MyTableType.sql")
 				.Contains("PRIMARY KEY"));
 		}
 
@@ -385,7 +385,7 @@ CREATE TYPE [dbo].[MyTableType] AS TABLE(
 			Assert.AreEqual("ComputedValue", db.TableTypes[0].Columns.Items[2].Name);
 			Assert.AreEqual("([VALUE1]+[VALUE2])", db.TableTypes[0].Columns.Items[2].ComputedDefinition);
 			Assert.AreEqual("MyTableType", db.TableTypes[0].Name);
-			Assert.IsTrue(File.Exists(db.Name + "\\table_types\\TYPE_MyTableType.sql"));
+			Assert.IsTrue(File.Exists(db.Name + "\\table_types\\TYPE_dbo.MyTableType.sql"));
 		}
 
 		[Test]
@@ -415,7 +415,7 @@ CREATE TYPE [dbo].[MyTableType] AS TABLE(
 			var constraint = db.TableTypes[0].Constraints.First();
 			Assert.AreEqual("([Value]>(0))", constraint.CheckConstraintExpression);
 			Assert.AreEqual("MyTableType", db.TableTypes[0].Name);
-			Assert.IsTrue(File.Exists(db.Name + "\\table_types\\TYPE_MyTableType.sql"));
+			Assert.IsTrue(File.Exists(db.Name + "\\table_types\\TYPE_dbo.MyTableType.sql"));
 		}
 
 		[Test]
@@ -445,7 +445,7 @@ CREATE TYPE [dbo].[MyTableType] AS TABLE(
 			Assert.AreEqual(" DEFAULT ((0))", db.TableTypes[0].Columns.Items[1].Default.ScriptCreate());
 
 			Assert.AreEqual("MyTableType", db.TableTypes[0].Name);
-			Assert.IsTrue(File.Exists(db.Name + "\\table_types\\TYPE_MyTableType.sql"));
+			Assert.IsTrue(File.Exists(db.Name + "\\table_types\\TYPE_dbo.MyTableType.sql"));
 		}
 
 		[Test]
@@ -549,7 +549,7 @@ CREATE TRIGGER [dbo].[TR_v1] ON [dbo].[v1] INSTEAD OF DELETE AS
 
 			Assert.AreEqual(1, triggers.Count());
 			Assert.AreEqual("TR_v1", triggers[0].Name);
-			Assert.IsTrue(File.Exists(db.Name + "\\triggers\\TR_v1.sql"));
+			Assert.IsTrue(File.Exists(db.Name + "\\triggers\\dbo.TR_v1.sql"));
 		}
 
 		[Test]
@@ -593,7 +593,7 @@ AS INSERT INTO [dbo].[t2](a) SELECT a FROM INSERTED";
 
 			db.ScriptToDir();
 
-			var script = File.ReadAllText(db.Name + "\\triggers\\TR_1.sql");
+			var script = File.ReadAllText(db.Name + "\\triggers\\dbo.TR_1.sql");
 
 			StringAssert.DoesNotContain("INSERTEDENABLE", script);
 		}
@@ -757,14 +757,14 @@ select * from Table1
 
 			foreach (var t in db.DataTables) {
 				if (t.Name == "EmptyTable") {
-					Assert.IsFalse(File.Exists(db.Name + "\\data\\" + t.Name + ".tsv"));
+					Assert.IsFalse(File.Exists(db.Name + "\\data\\dbo." + t.Name + ".tsv"));
 				} else {
-					Assert.IsTrue(File.Exists(db.Name + "\\data\\" + t.Name + ".tsv"));
+					Assert.IsTrue(File.Exists(db.Name + "\\data\\dbo." + t.Name + ".tsv"));
 				}
 			}
 
 			foreach (var t in db.Tables) {
-				var tblFile = db.Name + "\\tables\\" + t.Name + ".sql";
+				var tblFile = db.Name + "\\tables\\dbo." + t.Name + ".sql";
 				Assert.IsTrue(File.Exists(tblFile));
 
 				// Test that the constraints are ordered in the file
@@ -780,17 +780,17 @@ select * from Table1
 			}
 
 			foreach (var t in db.TableTypes) {
-				Assert.IsTrue(File.Exists(db.Name + "\\table_types\\TYPE_" + t.Name + ".sql"));
+				Assert.IsTrue(File.Exists(db.Name + "\\table_types\\TYPE_dbo." + t.Name + ".sql"));
 			}
 
 			foreach (var expected in db.ForeignKeys.Select(fk =>
-				db.Name + "\\foreign_keys\\" + fk.Table.Name + ".sql")) {
+				db.Name + "\\foreign_keys\\dbo." + fk.Table.Name + ".sql")) {
 				Assert.IsTrue(File.Exists(expected), "File does not exist" + expected);
 			}
 
 			// Test that the foreign keys are ordered in the file
 			foreach (var t in db.Tables) {
-				var fksFile = db.Name + "\\foreign_keys\\" + t.Name + ".sql";
+				var fksFile = db.Name + "\\foreign_keys\\dbo." + t.Name + ".sql";
 
 				if (File.Exists(fksFile)) {
 					var script = File.ReadAllText(fksFile);

--- a/test/Tests.csproj
+++ b/test/Tests.csproj
@@ -130,15 +130,11 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
-  <Import Project="..\packages\JetBrains.ReSharper.CommandLineTools.2020.1.0-eap02\build\JetBrains.ReSharper.CommandLineTools.targets" Condition="Exists('..\packages\JetBrains.ReSharper.CommandLineTools.2020.1.0-eap02\build\JetBrains.ReSharper.CommandLineTools.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\JetBrains.ReSharper.CommandLineTools.2020.1.0-eap02\build\JetBrains.ReSharper.CommandLineTools.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.ReSharper.CommandLineTools.2020.1.0-eap02\build\JetBrains.ReSharper.CommandLineTools.targets'))" />
-    <Error Condition="!Exists('..\packages\JetBrains.ReSharper.CommandLineTools.2020.1.3\build\JetBrains.ReSharper.CommandLineTools.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\JetBrains.ReSharper.CommandLineTools.2020.1.3\build\JetBrains.ReSharper.CommandLineTools.targets'))" />
   </Target>
-  <Import Project="..\packages\JetBrains.ReSharper.CommandLineTools.2020.1.3\build\JetBrains.ReSharper.CommandLineTools.targets" Condition="Exists('..\packages\JetBrains.ReSharper.CommandLineTools.2020.1.3\build\JetBrains.ReSharper.CommandLineTools.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/test/packages.config
+++ b/test/packages.config
@@ -1,9 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 
 <packages>
-  <package id="JetBrains.ReSharper.CommandLineTools" version="2020.1.3" targetFramework="net35"
-           developmentDependency="true" />
   <package id="NUnit" version="2.6.2" targetFramework="net35" />
   <package id="NUnit.Runners" version="2.6.2" targetFramework="net35" />
+  <package id="NUnitTestAdapter" version="2.1.1" targetFramework="net35" />
   <package id="ReGitLint" version="1.5.0" targetFramework="net35" />
 </packages>


### PR DESCRIPTION
Added 3 new options:

1. `timeout={secs}` - specify the commandTimeout for queries, as this could exceed the default 30 secs on slow machines or large databases.
2. `--noprefixdbo` - not prefixing dbo files is only set for backwards compatibility. The consensus seems to be that they should be. By default they will now be prefixed. This option allows for older code bases to turn that off for compatibility.
3. `schemas={a,b}` - an optional comma-separated list of schemas names. Only objects within these will be scripted (plus global objects such as users and assemblies). This is useful for us as we have a few dev-only schemas in our db which we do not want to script to source control.

Additionally, I have swapped out the resharper test tools for the Nunit Test Adapter, as the generic test runner has been built into VS for quite a while now.