### PR TITLE
Feature: Timeout Parameter

### DIFF
--- a/Console/BaseCommand.cs
+++ b/Console/BaseCommand.cs
@@ -1,5 +1,6 @@
 ﻿using ManyConsole;
 using Mono.Options;
+using System;
 
 namespace SchemaZen.Console;
 
@@ -30,6 +31,11 @@ public abstract class BaseCommand : ConsoleCommand {
 			"f|databaseFilesPath=",
 			"Path to database data and log files.",
 			o => DatabaseFilesPath = o);
+		HasOption(
+			"timeout=",
+			"Number of seconds for sql command timeout (default 30).",
+				o => TimeoutSec = (o == null ? 30 : Convert.ToInt32(o))
+		);
 	}
 
 	protected string Server { get; set; }
@@ -41,4 +47,5 @@ public abstract class BaseCommand : ConsoleCommand {
 	protected bool Overwrite { get; set; }
 	protected bool Verbose { get; set; }
 	protected string DatabaseFilesPath { get; set; }
+	protected int TimeoutSec { get; set; }
 }

--- a/Console/Create.cs
+++ b/Console/Create.cs
@@ -26,7 +26,8 @@ public class Create : BaseCommand {
 			Server = Server,
 			User = User,
 			Logger = _logger,
-			Overwrite = Overwrite
+			Overwrite = Overwrite,
+			TimeoutSec = TimeoutSec,
 		};
 
 		try {

--- a/Library/Command/BaseCommand.cs
+++ b/Library/Command/BaseCommand.cs
@@ -14,6 +14,7 @@ public abstract class BaseCommand {
 	public string ScriptDir { get; set; }
 	public ILogger Logger { get; set; }
 	public bool Overwrite { get; set; }
+	public int TimeoutSec { get; set; }
 
 	public Database CreateDatabase(IList<string> filteredTypes = null) {
 		filteredTypes = filteredTypes ?? new List<string>();
@@ -28,7 +29,8 @@ public abstract class BaseCommand {
 
 			return new Database(filteredTypes) {
 				Connection = ConnectionString,
-				Dir = ScriptDir
+				Dir = ScriptDir,
+				TimeoutSec = TimeoutSec,
 			};
 		}
 
@@ -42,7 +44,8 @@ public abstract class BaseCommand {
 			IntegratedSecurity = string.IsNullOrEmpty(User),
 			//setting up pooling false to avoid re-use of connection while using the library.
 			//http://www.c-sharpcorner.com/article/understanding-connection-pooling/
-			Pooling = false
+			Pooling = false,
+			ConnectTimeout = TimeoutSec,
 		};
 		if (!builder.IntegratedSecurity) {
 			builder.UserID = User;
@@ -51,7 +54,8 @@ public abstract class BaseCommand {
 
 		return new Database(filteredTypes) {
 			Connection = builder.ToString(),
-			Dir = ScriptDir
+			Dir = ScriptDir,
+			TimeoutSec = TimeoutSec,
 		};
 	}
 

--- a/Library/Models/Database.cs
+++ b/Library/Models/Database.cs
@@ -197,6 +197,7 @@ public class Database {
 	public string Dir { get; set; } = "";
 	public List<ForeignKey> ForeignKeys { get; set; } = new();
 	public string Name { get; set; }
+	public int TimeoutSec { get; set; }
 
 	public List<DbProp> Props { get; set; } = new();
 	public List<Routine> Routines { get; set; } = new();

--- a/Library/Models/Database.cs
+++ b/Library/Models/Database.cs
@@ -1407,7 +1407,7 @@ where name = @dbname
 
 			try {
 				log(TraceLevel.Verbose, $"Importing data for table {schema}.{table}...");
-				t.ImportData(Connection, fi.FullName);
+				t.ImportData(Connection, TimeoutSec, fi.FullName);
 			} catch (SqlBatchException ex) {
 				throw new DataFileException(ex.Message, fi.FullName, ex.LineNumber);
 			} catch (Exception ex) {

--- a/Library/Models/Table.cs
+++ b/Library/Models/Table.cs
@@ -195,7 +195,7 @@ public class Table : INameable, IHasOwner, IScriptable {
 		}
 	}
 
-	public void ImportData(string conn, string filename) {
+	public void ImportData(string conn, int timeoutSec, string filename) {
 		if (IsType)
 			throw new InvalidOperationException();
 
@@ -210,6 +210,7 @@ public class Table : INameable, IHasOwner, IScriptable {
 			       conn,
 			       SqlBulkCopyOptions.KeepIdentity | SqlBulkCopyOptions.KeepNulls |
 			       SqlBulkCopyOptions.TableLock)) {
+			bulk.BulkCopyTimeout = timeoutSec;
 			foreach (var colName in dt.Columns.OfType<DataColumn>().Select(c => c.ColumnName))
 				bulk.ColumnMappings.Add(colName, colName);
 			bulk.DestinationTableName = $"[{Owner}].[{Name}]";

--- a/Test/Integration/TableTest.cs
+++ b/Test/Integration/TableTest.cs
@@ -13,6 +13,8 @@ public class TableTest {
 
 	private readonly ILogger _logger;
 
+	private const int _timeoutSec = 30;
+
 	public TableTest(ITestOutputHelper output, TestDbHelper dbHelper) {
 		_logger = output.BuildLogger();
 		_dbHelper = dbHelper;
@@ -42,7 +44,7 @@ public class TableTest {
 		writer.Flush();
 		writer.Close();
 
-		t.ImportData(testDb.GetConnString(), filename);
+		t.ImportData(testDb.GetConnString(), _timeoutSec, filename);
 		var sw = new StringWriter();
 		t.ExportData(testDb.GetConnString(), sw);
 		Assert.Equal(dataIn, sw.ToString());
@@ -79,7 +81,7 @@ public class TableTest {
 		writer.Close();
 
 		try {
-			t.ImportData(testDb.GetConnString(), filename);
+			t.ImportData(testDb.GetConnString(), _timeoutSec, filename);
 			var sw = new StringWriter();
 			t.ExportData(testDb.GetConnString(), sw);
 			Assert.Equal(dataIn, sw.ToString());
@@ -112,7 +114,7 @@ public class TableTest {
 		writer.Close();
 
 		try {
-			t.ImportData(testDb.GetConnString(), filename);
+			t.ImportData(testDb.GetConnString(), _timeoutSec, filename);
 			var sw = new StringWriter();
 			t.ExportData(testDb.GetConnString(), sw);
 			Assert.Equal(dataIn, sw.ToString());
@@ -148,7 +150,7 @@ public class TableTest {
 		writer.Close();
 
 		try {
-			t.ImportData(testDb.GetConnString(), filename);
+			t.ImportData(testDb.GetConnString(), _timeoutSec, filename);
 			var sw = new StringWriter();
 			t.ExportData(testDb.GetConnString(), sw);
 			Assert.Equal(dataIn, sw.ToString());
@@ -196,7 +198,7 @@ public class TableTest {
 				filename)); // just prove that the file and the string are the same, to make the next assertion meaningful!
 
 		try {
-			t.ImportData(testDb.GetConnString(), filename);
+			t.ImportData(testDb.GetConnString(), _timeoutSec, filename);
 			var sw = new StringWriter();
 			t.ExportData(testDb.GetConnString(), sw);
 


### PR DESCRIPTION
This does 2 things:

1. Add a `--timeout` parameter to BaseCommand.
2. Implement the timeout parameter for importing data during `schemazen create`.

This is not a complete timeout for everything, but it is a solution for #62 import timeout issues, which I also had and needed to fix. 

#193 implements a timeout for `schemazen script`, which this does not do. Thank you to @rhumborl for giving me enough code in the diffs to make figuring out this patch much quicker.