### PR TITLE
Refactored Hex String conversion with support for net48

### DIFF
--- a/Library/Library.csproj
+++ b/Library/Library.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <LangVersion>10.0</LangVersion>
-    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net5.0;net6.0;net48</TargetFrameworks>
     <OutputType>Library</OutputType>
     <RootNamespace>SchemaZen.Library</RootNamespace>
     <AssemblyName>SchemaZen.Library</AssemblyName>
@@ -23,5 +23,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
+    <PackageReference Include="System.Runtime.Extensions" Version="4.3.1" />
   </ItemGroup>
 </Project>

--- a/Library/Models/Assembly.cs
+++ b/Library/Models/Assembly.cs
@@ -26,12 +26,12 @@ public class SqlAssembly : INameable, IScriptable {
 			(kvp, index) => {
 				if (index == 0)
 					return $@"CREATE ASSEMBLY [{Name}]
-{string.Empty}FROM {"0x" + Convert.ToHexString(kvp.Value)}
+{string.Empty}FROM {"0x" + StringUtil.ToHexString(kvp.Value)}
 {"WITH PERMISSION_SET = " + PermissionSet}";
 
 				return
 					$@"ALTER ASSEMBLY [{Name}]
-ADD FILE FROM {"0x" + Convert.ToHexString(kvp.Value)}
+ADD FILE FROM {"0x" + StringUtil.ToHexString(kvp.Value)}
 AS N\'{kvp.Key}\'";
 			});
 

--- a/Library/Models/SqlUser.cs
+++ b/Library/Models/SqlUser.cs
@@ -20,7 +20,7 @@ public class SqlUser : INameable, IHasOwner, IScriptable {
 		var login = PasswordHash == null
 			? string.Empty
 			: $@"IF SUSER_ID('{Name}') IS NULL
-				BEGIN CREATE LOGIN {Name} WITH PASSWORD = {"0x" + Convert.ToHexString(PasswordHash)} HASHED END
+				BEGIN CREATE LOGIN {Name} WITH PASSWORD = {"0x" + StringUtil.ToHexString(PasswordHash)} HASHED END
 ";
 
 		return login +

--- a/Library/Models/Table.cs
+++ b/Library/Models/Table.cs
@@ -165,7 +165,7 @@ public class Table : INameable, IHasOwner, IScriptable {
 							if (dr[c.Name] is DBNull)
 								data.Write(_nullValue);
 							else if (dr[c.Name] is byte[])
-								data.Write(Convert.ToHexString((byte[])dr[c.Name]));
+								data.Write(StringUtil.ToHexString((byte[])dr[c.Name]));
 							else if (dr[c.Name] is DateTime)
 								data.Write(
 									((DateTime)dr[c.Name])
@@ -311,7 +311,7 @@ public class Table : INameable, IHasOwner, IScriptable {
 			case "binary":
 			case "varbinary":
 			case "image":
-				return Convert.FromHexString(val);
+				return StringUtil.FromHexString(val);
 			default:
 				return val;
 		}

--- a/Library/StringUtil.cs
+++ b/Library/StringUtil.cs
@@ -1,4 +1,6 @@
-﻿namespace SchemaZen.Library {
+﻿using System;
+
+namespace SchemaZen.Library {
 	public class StringUtil {
 		/// <summary>
 		///     Adds a space to the beginning of a string.
@@ -7,6 +9,65 @@
 		public static string AddSpaceIfNotEmpty(string val) {
 			if (string.IsNullOrEmpty(val)) return val;
 			return $" {val}";
+		}
+
+		/// <summary>
+		///     Converts an array of 8-bit unsigned integers to its equivalent string representation that is encoded with uppercase hex characters.
+		///     This method acts as a proxy between different framework implementations
+		/// </summary>
+		public static byte[] FromHexString(string s) {
+#if NET5_0_OR_GREATER
+			return Convert.FromHexString(s);
+#else
+			return HexStringToByteArrayV5_3(s);
+#endif
+		}
+
+		/// <summary>
+		/// From: https://stackoverflow.com/a/68066131/198452
+		/// </summary>
+		private static byte[] HexStringToByteArrayV5_3(string hexString) {
+			int hexStringLength = hexString.Length;
+			byte[] b = new byte[hexStringLength / 2];
+			for (int i = 0; i < hexStringLength; i += 2) {
+				int topChar = hexString[i];
+				topChar = (topChar > 0x40 ? (topChar & ~0x20) - 0x37 : topChar - 0x30) << 4;
+				int bottomChar = hexString[i + 1];
+				bottomChar = bottomChar > 0x40 ? (bottomChar & ~0x20) - 0x37 : bottomChar - 0x30;
+				b[i / 2] = (byte)(topChar + bottomChar);
+			}
+			return b;
+		}
+
+
+		/// <summary>
+		///     Converts the specified string, which encodes binary data as hex characters, to an equivalent 8-bit unsigned integer array.
+		///     This method acts as a proxy between different framework implementations
+		/// </summary>
+		public static string ToHexString(byte[] inArray)
+		{
+#if NET5_0_OR_GREATER
+			return Convert.ToHexString(inArray);
+#else
+			return ByteArrayToHex(inArray);
+#endif
+		}
+
+		/// <summary>
+		/// From: https://stackoverflow.com/a/632920/198452
+		/// </summary>
+		private static string ByteArrayToHex(byte[] barray)
+		{
+			char[] c = new char[barray.Length * 2];
+			byte b;
+			for (int i = 0; i < barray.Length; ++i)
+			{
+				b = ((byte)(barray[i] >> 4));
+				c[i * 2] = (char)(b > 9 ? b + 0x37 : b + 0x30);
+				b = ((byte)(barray[i] & 0xF));
+				c[i * 2 + 1] = (char)(b > 9 ? b + 0x37 : b + 0x30);
+			}
+			return new string(c);
 		}
 	}
 


### PR DESCRIPTION
All calls to `Convert.ToHexString` and `Convert.ToHexString` have been pointed at `StringUtil`.
A preprocessor directive switches code between the two framework range options.
`net48` has been added to `Library.csproj` `<TargetFrameworks>`. Earlier versions may be compatible but have not been tested.