### PR TITLE
Added square brackets around create login names

### DIFF
--- a/Library/Models/SqlUser.cs
+++ b/Library/Models/SqlUser.cs
@@ -20,7 +20,7 @@ public class SqlUser : INameable, IHasOwner, IScriptable {
 		var login = PasswordHash == null
 			? string.Empty
 			: $@"IF SUSER_ID('{Name}') IS NULL
-				BEGIN CREATE LOGIN {Name} WITH PASSWORD = {"0x" + StringUtil.ToHexString(PasswordHash)} HASHED END
+				BEGIN CREATE LOGIN [{Name}] WITH PASSWORD = {"0x" + StringUtil.ToHexString(PasswordHash)} HASHED END
 ";
 
 		return login +


### PR DESCRIPTION
Users with '-' in the names create invalid user scripts because the create login part does not use square brackets to wrap the name